### PR TITLE
API Summary Style Customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,4 @@
-[![Published on NPM](https://img.shields.io/npm/v/@api-components/api-summary.svg)](https://www.npmjs.com/package/@api-components/api-summary)
-
-[![Build Status](https://travis-ci.org/advanced-rest-client/api-summary.svg?branch=stage)](https://travis-ci.org/advanced-rest-client/api-summary)
-
-[![Published on webcomponents.org](https://img.shields.io/badge/webcomponents.org-published-blue.svg)](https://www.webcomponents.org/element/@api-components/api-summary)
-
-# &lt;api-summary&gt;
+# api-summary
 
 A component that renders basic information about an API.
 It uses AMF model to render the view.
@@ -48,6 +42,35 @@ npm install --save @api-components/api-summary
   </body>
 </html>
 ```
+
+### Styling using CSS Shadow Parts
+
+```html
+<html>
+  <head>
+    <script type="module">
+      import '@api-components/api-summary/api-summary.js';
+    </script>
+    <style type="text/css">
+      api-summary::part(api-title) {
+        font-size: 24px;
+      }
+    </style>
+  </head>
+  <body>
+    <api-summary exportparts="api-title"></api-summary>
+    <script>
+    const amf = await getAmfModel();
+    document.body.querySelector('api-summary').api = amf;
+    window.addEventListener('api-navigation-selection-changed', (e) => {
+      console.log(e.detail.selected);
+      console.log(e.detail.type);
+    });
+    </script>
+  </body>
+</html>
+```
+For a complete list of parts, check out this [doc](./Styling.md).
 
 ### In a LitElement template
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-# api-summary
+[![Published on NPM](https://img.shields.io/npm/v/@api-components/api-summary.svg)](https://www.npmjs.com/package/@api-components/api-summary)
+
+[![Build Status](https://travis-ci.org/advanced-rest-client/api-summary.svg?branch=stage)](https://travis-ci.org/advanced-rest-client/api-summary)
+
+[![Published on webcomponents.org](https://img.shields.io/badge/webcomponents.org-published-blue.svg)](https://www.webcomponents.org/element/@api-components/api-summary)
+
+# &lt;api-summary&gt;
 
 A component that renders basic information about an API.
 It uses AMF model to render the view.

--- a/Styling.md
+++ b/Styling.md
@@ -1,0 +1,13 @@
+# Styling
+
+## List of CSS Shadow Parts
+ 
+- `api-title`
+- `api-title-label`
+- `api-version`
+- `marked-description`
+- `info-section`
+- `info-inline-desc`
+- `license-section`
+- `separator`
+- `toc`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-components/api-summary",
-  "version": "4.5.0",
+  "version": "4.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-summary",
   "description": "A summary view for an API base on AMF data model",
-  "version": "4.5.0",
+  "version": "4.6.0",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/src/ApiSummary.d.ts
+++ b/src/ApiSummary.d.ts
@@ -24,6 +24,10 @@ export declare class ApiSummary extends AmfHelperMixin(LitElement) {
    * @attribute
    */
   titleLevel: string;
+  /**
+   * A property to hide the table of contents list of endpoints.
+   */
+  hideToc: boolean;
 
   _providerName: string;
   _providerEmail: string;

--- a/src/ApiSummary.js
+++ b/src/ApiSummary.js
@@ -331,7 +331,7 @@ export class ApiSummary extends AmfHelperMixin(LitElement) {
       return '';
     }
     return html`
-    <div class="api-title" role="heading" aria-level="${titleLevel}">
+    <div class="api-title" role="heading" aria-level="${titleLevel}" part="api-title">
     <label>API title:</label>
     <span>${_apiTitle}</span>
     </div>`;
@@ -343,7 +343,7 @@ export class ApiSummary extends AmfHelperMixin(LitElement) {
       return '';
     }
     return html`
-    <p class="inline-description version">
+    <p class="inline-description version" part="api-version">
       <label>Version:</label>
       <span>${_version}</span>
     </p>`;
@@ -355,7 +355,7 @@ export class ApiSummary extends AmfHelperMixin(LitElement) {
       return '';
     }
     return html`
-    <div role="region" class="marked-description">
+    <div role="region" class="marked-description" part="marked-description">
       <arc-marked .markdown="${_description}" sanitize>
         <div slot="markdown-html" class="markdown-body"></div>
       </arc-marked>
@@ -427,16 +427,16 @@ export class ApiSummary extends AmfHelperMixin(LitElement) {
       `<a href="${_providerUrl}" target="_blank" class="app-link provider-url">${_providerUrl}</a>`,
     ): undefined;
     return html`
-    <section role="contentinfo" class="docs-section">
+    <section role="contentinfo" class="docs-section" part="info-section">
       <label class="section">Contact information</label>
-      <p class="inline-description">
+      <p class="inline-description" part="info-inline-desc">
         <span class="provider-name">${_providerName}</span>
         ${_providerEmail ? html`<a
             class="app-link link-padding provider-email"
             href="mailto:${_providerEmail}">${_providerEmail}</a>` : ''}
       </p>
       ${_providerUrl ? html`
-        <p class="inline-description">
+        <p class="inline-description" part="info-inline-desc">
           ${unsafeHTML(link)}
         </p>` : ''}
     </section>`;
@@ -451,7 +451,7 @@ export class ApiSummary extends AmfHelperMixin(LitElement) {
       `<a href="${_licenseUrl}" target="_blank" class="app-link">${_licenseName}</a>`,
     );
     return html`
-    <section aria-labelledby="licenseLabel" class="docs-section">
+    <section aria-labelledby="licenseLabel" class="docs-section" part="license-section">
       <label class="section" id="licenseLabel">License</label>
       <p class="inline-description">
         ${unsafeHTML(link)}

--- a/src/ApiSummary.js
+++ b/src/ApiSummary.js
@@ -43,6 +43,10 @@ export class ApiSummary extends AmfHelperMixin(LitElement) {
        * @default 2
        */
       titleLevel: { type: String },
+      /**
+       * A property to hide the table of contents list of endpoints.
+       */
+      hideToc: { type: Boolean },
 
       _providerName: { type: String },
       _providerEmail: { type: String },
@@ -99,6 +103,7 @@ export class ApiSummary extends AmfHelperMixin(LitElement) {
      * @type {string[]}
      */
     this.protocols = undefined;
+    this.hideToc = false;
   }
 
   __amfChanged() {
@@ -321,7 +326,7 @@ export class ApiSummary extends AmfHelperMixin(LitElement) {
         ${this._termsOfServiceTemplate()}
       </div>
 
-      ${this._endpointsTemplate()}
+      ${this.hideToc ? '' : this._endpointsTemplate()}
     `;
   }
 

--- a/src/ApiSummary.js
+++ b/src/ApiSummary.js
@@ -332,7 +332,7 @@ export class ApiSummary extends AmfHelperMixin(LitElement) {
     }
     return html`
     <div class="api-title" role="heading" aria-level="${titleLevel}" part="api-title">
-    <label>API title:</label>
+    <label part="api-title-label">API title:</label>
     <span>${_apiTitle}</span>
     </div>`;
   }
@@ -481,8 +481,8 @@ export class ApiSummary extends AmfHelperMixin(LitElement) {
     const result = _endpoints.map((item) => this._endpointTemplate(item));
     const pathLabel = this._isAsyncAPI(this.amf) ? 'channels' : 'endpoints';
     return html`
-    <div class="separator"></div>
-    <div class="toc">
+    <div class="separator" part="separator"></div>
+    <div class="toc" part="toc">
       <label class="section endpoints-title">API ${pathLabel}</label>
       ${result}
     </div>

--- a/src/Styles.js
+++ b/src/Styles.js
@@ -102,7 +102,7 @@ a:hover {
 .separator {
   background-color: var(--api-summary-separator-color, rgba(0, 0, 0, 0.12));
   height: 1px;
-  margin: var(--api-summary-separator-margin-y, 40px) var(--api-summary-separator-margin-x, 0);
+  margin: var(--api-summary-separator-margin, 40px 0);
 }
 
 .endpoint-item {

--- a/src/Styles.js
+++ b/src/Styles.js
@@ -102,7 +102,7 @@ a:hover {
 .separator {
   background-color: var(--api-summary-separator-color, rgba(0, 0, 0, 0.12));
   height: 1px;
-  margin: 40px 0;
+  margin: var(--api-summary-separator-margin-y, 40px) var(--api-summary-separator-margin-x, 0);
 }
 
 .endpoint-item {

--- a/test/api-summary.test.js
+++ b/test/api-summary.test.js
@@ -44,8 +44,8 @@ describe('ApiSummary', () => {
 
         it('renders api title', () => {
           const node = element.shadowRoot.querySelector('[role="heading"]');
-          assert.dom.equal(node, `<div aria-level="2" class="api-title" role="heading">
-            <label>
+          assert.dom.equal(node, `<div aria-level="2" class="api-title" role="heading" part="api-title">
+            <label part="api-title-label">
               API title:
             </label>
             <span>
@@ -95,6 +95,11 @@ describe('ApiSummary', () => {
         it('renders base uri', () => {
           const node = element.shadowRoot.querySelector('api-url');
           assert.equal(node.url, `https://{instance}.domain.com`);
+        });
+
+        it('renders endpoints template', () => {
+          const node = element.shadowRoot.querySelector('.endpoints-title');
+          assert.dom.equal(node, `<label class="endpoints-title section">API endpoints</label>`);
         });
       });
 
@@ -409,6 +414,24 @@ describe('ApiSummary', () => {
 
         it('should render "API channels" message', () => {
           assert.equal(element.shadowRoot.querySelector('.section.endpoints-title').textContent, 'API channels');
+        });
+      });
+
+      describe('hideToc', () => {
+        let element = /** @type ApiSummary */ (null);
+        let amf;
+        before(async () => {
+          amf = await AmfLoader.load(compact);
+        });
+        beforeEach(async () => {
+          element = await basicFixture();
+          element.setAttribute('hideToc', 'true');
+          await aTimeout(0);
+        });
+
+        it('does not render endpoints template', () => {
+          const node = element.shadowRoot.querySelector('.toc');
+          assert.isNull(node);
         });
       });
     });


### PR DESCRIPTION
Fixes [#27](https://github.com/advanced-rest-client/api-documentation/issues/27)

- Add CSS parts to major sections
- Add api to not render the endpoints table of contents
- customize separator margin