### PR TITLE
@W-20242139 OpenAPI Tags-Based Endpoint Grouping Support

### DIFF
--- a/demo/apis.json
+++ b/demo/apis.json
@@ -18,5 +18,6 @@
   },
   "APIC-641/APIC-641.yaml": { "type": "OAS 3.0", "mime": "application/yaml" },
   "APIC-711/APIC-711.raml": "RAML 1.0",
-  "agents-api/agents-api.yaml": { "type": "OAS 3.0", "mime": "application/yaml" }
+  "agents-api/agents-api.yaml": { "type": "OAS 3.0", "mime": "application/yaml" },
+  "tags-flights/tags-flights.yml": { "type": "OAS 3.0", "mime": "application/yaml" }
 }

--- a/demo/index.js
+++ b/demo/index.js
@@ -13,6 +13,7 @@ class ApiDemo extends ApiDemoPage {
 
   _apiListTemplate() {
     return [
+      ["tags-flights", "Tags Flights"],
       ["agents-api", "Agents API"],
       ["google-drive-api", "Google Drive"],
       ["exchange-experience-api", "Exchange xAPI"],

--- a/demo/tags-flights/tags-flights.yml
+++ b/demo/tags-flights/tags-flights.yml
@@ -1,0 +1,42 @@
+openapi: 3.0.3
+info:
+  title: Flights API
+  version: v1
+tags:
+  - name: AllFlights
+    description: Operations related to all flights
+  - name: OneFlight
+    description: Operations related to a single flight
+paths:
+  /flights:
+    get:
+      tags:
+        - AllFlights
+      summary: List all flights
+      operationId: getAllFlights
+      responses:
+        '200':
+          description: Successful response
+    post:
+      tags:
+        - AllFlights
+      summary: Create a new flight
+      operationId: createFlight
+      responses:
+        '201':
+          description: Flight created
+  /flights/{ID}:
+    get:
+      tags:
+        - OneFlight
+      summary: Get a single flight by ID
+      operationId: getOneFlight
+      parameters:
+        - name: ID
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful response

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@api-components/api-summary",
-  "version": "4.6.12",
+  "version": "4.6.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@api-components/api-summary",
-      "version": "4.6.12",
+      "version": "4.6.13",
       "license": "Apache-2.0",
       "dependencies": {
         "@advanced-rest-client/arc-marked": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-summary",
   "description": "A summary view for an API base on AMF data model",
-  "version": "4.6.12",
+  "version": "4.6.13",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/src/ApiSummary.js
+++ b/src/ApiSummary.js
@@ -744,7 +744,6 @@ export class ApiSummary extends AmfHelperMixin(LitElement) {
   }
 
   _endpointTemplate(item) {
-    debugger;
     const ops =
       item.ops && item.ops.length
         ? item.ops.map((op) => this._methodTemplate(op, item))

--- a/src/ApiSummary.js
+++ b/src/ApiSummary.js
@@ -9,7 +9,7 @@ import labelStyles from "@api-components/http-method-label/http-method-label-com
 import sanitizer from "dompurify";
 import "@advanced-rest-client/arc-marked/arc-marked.js";
 import "@api-components/api-method-documentation/api-url.js";
-import { codegenie } from '@advanced-rest-client/icons/ArcIcons.js';
+import { codegenie } from "@advanced-rest-client/icons/ArcIcons.js";
 
 import styles from "./Styles.js";
 
@@ -290,14 +290,174 @@ export class ApiSummary extends AmfHelperMixin(LitElement) {
       return undefined;
     }
     return endpoints.map((item) => {
+      const path = this._getValue(
+        item,
+        this.ns.aml.vocabularies.apiContract.path
+      );
+      const pathStr = typeof path === "string" ? path : String(path || "");
+      const supportedOperations = this._endpointOperations(item);
+      const endpointDisplayInfo = this._computeEndpointName(
+        item,
+        webApi,
+        supportedOperations
+      );
       const result = {
-        name: this._getValue(item, this.ns.aml.vocabularies.core.name),
-        path: this._getValue(item, this.ns.aml.vocabularies.apiContract.path),
-        id: item["@id"],
-        ops: this._endpointOperations(item),
+         name: endpointDisplayInfo?.name,
+         description: endpointDisplayInfo?.description,
+         path: pathStr,
+         id: item["@id"],
+         ops: supportedOperations,
       };
       return result;
     });
+  }
+
+  /**
+   * Computes a descriptive name for an endpoint based on its operations and tags.
+   * @param {any} endpoint Endpoint model
+   * @param {any} webApi Web API model
+   * @param {any[]} ops Operations for this endpoint
+   * @return {Object|undefined} Object with name and description, or undefined
+   */
+  _computeEndpointName(endpoint, webApi, ops) {
+    // First try to get explicit name from endpoint
+    const explicitName = this._getValue(
+      endpoint,
+      this.ns.aml.vocabularies.core.name
+    );
+    if (explicitName && typeof explicitName === "string") {
+      return { name: explicitName, description: undefined };
+    }
+
+    // Try to get name from the most common tag
+    if (ops && ops.length > 0) {
+      const tagInfo = this._getEndpointTagInfo(endpoint, webApi);
+      if (tagInfo) {
+        return tagInfo;
+      }
+
+      // Try to get name from operation summaries
+      const operationName = this._getEndpointOperationName(endpoint);
+      if (operationName) {
+        return { name: operationName, description: undefined };
+      }
+    }
+
+    // Fallback: return undefined so path is used
+    return undefined;
+  }
+
+  /**
+   * Gets the tag info (name and description) for an endpoint based on its operations.
+   * @param {any} endpoint Endpoint model
+   * @param {any} webApi Web API model
+   * @return {Object|undefined} Object with name and description
+   */
+  _getEndpointTagInfo(endpoint, webApi) {
+    const operationsKey = this._getAmfKey(
+      this.ns.aml.vocabularies.apiContract.supportedOperation
+    );
+    const operations = this._ensureArray(endpoint[operationsKey]);
+
+    if (!operations || !operations.length) {
+      return undefined;
+    }
+
+    // Collect all tags from all operations
+    const tagKey = this._getAmfKey(this.ns.aml.vocabularies.apiContract.tag);
+    const allTags = [];
+
+    operations.forEach((operation) => {
+      const operationTags = this._ensureArray(operation[tagKey]);
+      if (operationTags && operationTags.length) {
+        operationTags.forEach((tag) => {
+          const tagName = this._getValue(
+            tag,
+            this.ns.aml.vocabularies.core.name
+          );
+          if (tagName && typeof tagName === "string") {
+            allTags.push(tagName);
+          }
+        });
+      }
+    });
+
+    if (!allTags.length) {
+      return undefined;
+    }
+
+    // Find the most common tag (or just use the first one if all are unique)
+    const tagCounts = {};
+    allTags.forEach((tagName) => {
+      tagCounts[tagName] = (tagCounts[tagName] || 0) + 1;
+    });
+
+    // Get the tag with the highest count (most common)
+    const tagNames = Object.keys(tagCounts);
+    const mostCommonTag = tagNames.reduce(
+      (a, b) => (tagCounts[a] > tagCounts[b] ? a : b),
+      tagNames[0]
+    );
+
+    // Find the tag definition in the webApi to get its description
+    const webApiTagsKey = this._getAmfKey(
+      this.ns.aml.vocabularies.apiContract.tag
+    );
+    const webApiTags = this._ensureArray(webApi[webApiTagsKey]);
+
+    if (webApiTags) {
+      const matchingTag = webApiTags.find((tag) => {
+        const name = this._getValue(tag, this.ns.aml.vocabularies.core.name);
+        return name === mostCommonTag;
+      });
+
+      if (matchingTag) {
+        const description = this._getValue(
+          matchingTag,
+          this.ns.aml.vocabularies.core.description
+        );
+        return {
+          name: mostCommonTag,
+          description:
+            description && typeof description === "string"
+              ? description
+              : undefined,
+        };
+      }
+    }
+
+    return { name: mostCommonTag, description: undefined };
+  }
+
+  /**
+   * Gets a descriptive name from operation summaries.
+   * @param {any} endpoint Endpoint model
+   * @return {string|undefined}
+   */
+  _getEndpointOperationName(endpoint) {
+    const operationsKey = this._getAmfKey(
+      this.ns.aml.vocabularies.apiContract.supportedOperation
+    );
+    const operations = this._ensureArray(endpoint[operationsKey]);
+
+    if (!operations || !operations.length) {
+      return undefined;
+    }
+
+    // Only use the summary if there's exactly one operation
+    if (operations.length === 1) {
+      const firstOp = operations[0];
+      const summary = this._getValue(
+        firstOp,
+        this.ns.aml.vocabularies.apiContract.guiSummary
+      );
+
+      if (summary && typeof summary === "string") {
+        return summary;
+      }
+    }
+
+    return undefined;
   }
 
   /**
@@ -571,6 +731,7 @@ export class ApiSummary extends AmfHelperMixin(LitElement) {
     if (!_endpoints || !_endpoints.length) {
       return "";
     }
+    debugger;
     const result = _endpoints.map((item) => this._endpointTemplate(item));
     const pathLabel = this._isAsyncAPI(this.amf) ? "channels" : "endpoints";
     return html`
@@ -583,6 +744,7 @@ export class ApiSummary extends AmfHelperMixin(LitElement) {
   }
 
   _endpointTemplate(item) {
+    debugger;
     const ops =
       item.ops && item.ops.length
         ? item.ops.map((op) => this._methodTemplate(op, item))
@@ -613,15 +775,20 @@ export class ApiSummary extends AmfHelperMixin(LitElement) {
       return "";
     }
     return html`
+      <p class="endpoint-name-description">
+        <span class="endpoint-name">${item.name}</span>${item.description
+          ? html` -
+              <span class="endpoint-description">${item.description}</span>`
+          : ""}
+      </p>
       <a
         class="endpoint-path"
         href="#${item.path}"
         data-id="${item.id}"
         data-shape-type="endpoint"
         title="Open endpoint documentation"
-        >${item.name}</a
+        >${item.path}</a
       >
-      <p class="endpoint-path-name">${item.path}</p>
     `;
   }
 
@@ -635,11 +802,9 @@ export class ApiSummary extends AmfHelperMixin(LitElement) {
         data-shape-type="method"
         title="Open method documentation"
         >${item.method}
-        ${
-          item.hasAgent 
-          ? html`<span class="method-icon">${codegenie}</span>` 
-          : ""
-        }
+        ${item.hasAgent
+          ? html`<span class="method-icon">${codegenie}</span>`
+          : ""}
       </a>
     `;
   }

--- a/src/Styles.js
+++ b/src/Styles.js
@@ -164,6 +164,21 @@ export default css`
     font-size: var(--arc-font-title-font-size);
   }
 
+  .endpoint-name-description {
+    margin: 4px 0;
+    font-size: var(--api-summary-endpoint-description-font-size, 0.9em);
+  }
+
+  .endpoint-name {
+    font-weight: var(--api-summary-endpoint-name-font-weight, 600);
+    color: var(--arc-font-title-color, var(--api-summary-endpoint-name-color, #333));
+  }
+
+  .endpoint-description {
+    font-style: italic;
+    color: var(--api-summary-endpoint-description-color, #666);
+  }
+
   .endpoint-path-name {
     word-break: break-all;
     margin: 8px 0;

--- a/test/api-summary.test.js
+++ b/test/api-summary.test.js
@@ -264,38 +264,31 @@ describe('ApiSummary', () => {
         });
 
         it('renders endpoint name', () => {
-          const node = element.shadowRoot.querySelectorAll('.endpoint-item')[2].querySelector('.endpoint-path');
+          const node = element.shadowRoot.querySelectorAll('.endpoint-item')[2].querySelector('.endpoint-name');
           assert.dom.equal(
             node,
-            `<a
-              class="endpoint-path"
-              data-shape-type="endpoint"
-              href="#/people"
-              title="Open endpoint documentation"
-              >
-              People
-            </a>`,
+            `<span class="endpoint-name">People</span>`,
             {
-              ignoreAttributes: ['data-id']
+              ignoreAttributes: []
             }
           );
-        });
-
-        it('sets data-id on name', () => {
-          const node = element.shadowRoot.querySelectorAll('.endpoint-item')[2].querySelector('.endpoint-path');
-          assert.ok(node.getAttribute('data-id'));
-        });
-
-        it('renders endpoint path with name', () => {
-          const node = element.shadowRoot.querySelectorAll('.endpoint-item')[2].querySelector('.endpoint-path-name');
-          assert.dom.equal(node, `<p class="endpoint-path-name">/people</p>`, {
-            ignoreAttributes: ['data-id']
-          });
         });
 
         it('sets data-id on path', () => {
           const node = element.shadowRoot.querySelectorAll('.endpoint-item')[2].querySelector('.endpoint-path');
           assert.ok(node.getAttribute('data-id'));
+        });
+
+        it('renders endpoint path with name', () => {
+          const node = element.shadowRoot.querySelectorAll('.endpoint-item')[2].querySelector('.endpoint-path');
+          assert.dom.equal(node, `<a
+            class="endpoint-path"
+            data-shape-type="endpoint"
+            href="#/people"
+            title="Open endpoint documentation"
+            >/people</a>`, {
+            ignoreAttributes: ['data-id']
+          });
         });
 
         it('renders list of operations', () => {

--- a/test/api-summary.test.js
+++ b/test/api-summary.test.js
@@ -572,6 +572,91 @@ describe('ApiSummary', () => {
     });
   });
 
+  describe('Tags-based endpoint grouping', () => {
+    [
+      ['Full AMF model', false],
+      ['Compact AMF model', true]
+    ].forEach(([label, compact]) => {
+      describe(String(label), () => {
+        let element = /** @type ApiSummary */ (null);
+        let amf;
+
+        before(async () => {
+          amf = await AmfLoader.load(compact, 'tags-flights');
+        });
+
+        beforeEach(async () => {
+          element = await basicFixture();
+          element.amf = amf;
+          await aTimeout(0);
+        });
+
+        it('renders all endpoints grouped by tags', () => {
+          const nodes = element.shadowRoot.querySelectorAll('.endpoint-item');
+          assert.lengthOf(nodes, 2, 'Should have 2 endpoint groups');
+        });
+
+        it('renders first endpoint with tag name "AllFlights"', () => {
+          const node = element.shadowRoot.querySelectorAll('.endpoint-item')[0].querySelector('.endpoint-name');
+          assert.ok(node, 'Should have endpoint name element');
+          assert.equal(node.textContent.trim(), 'AllFlights');
+        });
+
+        it('renders first endpoint description', () => {
+          const node = element.shadowRoot.querySelectorAll('.endpoint-item')[0].querySelector('.endpoint-description');
+          assert.ok(node, 'Should have endpoint description element');
+          assert.equal(node.textContent.trim(), 'Operations related to all flights');
+        });
+
+        it('renders first endpoint path', () => {
+          const node = element.shadowRoot.querySelectorAll('.endpoint-item')[0].querySelector('.endpoint-path');
+          assert.ok(node, 'Should have endpoint path element');
+          assert.equal(node.textContent.trim(), '/flights');
+        });
+
+        it('renders two operations for first endpoint', () => {
+          const nodes = element.shadowRoot.querySelectorAll('.endpoint-item')[0].querySelectorAll('.method-label');
+          assert.lengthOf(nodes, 2, 'Should have 2 operations (GET, POST)');
+        });
+
+        it('renders GET and POST methods for first endpoint', () => {
+          const nodes = element.shadowRoot.querySelectorAll('.endpoint-item')[0].querySelectorAll('.method-label');
+          const methods = Array.from(nodes).map(n => n.textContent.trim());
+          assert.include(methods, 'get');
+          assert.include(methods, 'post');
+        });
+
+        it('renders second endpoint with tag name "OneFlight"', () => {
+          const node = element.shadowRoot.querySelectorAll('.endpoint-item')[1].querySelector('.endpoint-name');
+          assert.ok(node, 'Should have endpoint name element');
+          assert.equal(node.textContent.trim(), 'OneFlight');
+        });
+
+        it('renders second endpoint description', () => {
+          const node = element.shadowRoot.querySelectorAll('.endpoint-item')[1].querySelector('.endpoint-description');
+          assert.ok(node, 'Should have endpoint description element');
+          assert.equal(node.textContent.trim(), 'Operations related to a single flight');
+        });
+
+        it('renders second endpoint path', () => {
+          const node = element.shadowRoot.querySelectorAll('.endpoint-item')[1].querySelector('.endpoint-path');
+          assert.ok(node, 'Should have endpoint path element');
+          assert.equal(node.textContent.trim(), '/flights/{ID}');
+        });
+
+        it('renders one operation for second endpoint', () => {
+          const nodes = element.shadowRoot.querySelectorAll('.endpoint-item')[1].querySelectorAll('.method-label');
+          assert.lengthOf(nodes, 1, 'Should have 1 operation (GET)');
+        });
+
+        it('renders GET method for second endpoint', () => {
+          const node = element.shadowRoot.querySelectorAll('.endpoint-item')[1].querySelector('.method-label');
+          assert.equal(node.textContent.trim(), 'get');
+        });
+      });
+    });
+  });
+
   describe('a11y', () => {
     let amf;
     let element = /** @type ApiSummary */ (null);


### PR DESCRIPTION
# OpenAPI Tags-Based Endpoint Grouping Support

## Bug Report

**Work ID:** [W-20242139](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002PZE1GYAX/view) 

**Issue Description:**  
The "tags" property defined at the operation level in OpenAPI specifications was not being rendered in the API Console. Users utilize the tags property to logically group related operations, which displays properly in Swagger Editor but was completely absent in API Console Builder (ACB). This created a usability gap where API consumers could not see the intended logical organization of operations.

<img width="325" height="337" alt="tags-in-api-console" src="https://github.com/user-attachments/assets/c0a85644-905f-43e3-9634-341f46f09d5c" />
<img width="322" height="419" alt="tags-in-swagger-editor (1)" src="https://github.com/user-attachments/assets/6f73c822-a978-4775-bccc-8e99ee3c13d0" />


## Solution Overview

This update adds full support for rendering and grouping API endpoints by their OpenAPI tags in the API summary component. When operations share common tags, they are now displayed together with the tag name and description prominently shown, matching the expected behavior from tools like Swagger Editor.

<img width="515" height="317" alt="Screenshot 2025-12-16 at 2 18 00 PM" src="https://github.com/user-attachments/assets/4dff26f1-f8f3-482e-bdee-f33c776aa753" />


## Core Functionality

### New Helper Methods

**`_computeEndpointName(endpoint, webApi, ops)`**  
Determines the display name for an endpoint following a priority hierarchy. Returns an object with name and description properties, or undefined to fallback to the path.

**`_getEndpointTagInfo(endpoint, webApi)`**  
Extracts tag information from endpoint operations. When multiple operations share tags, it identifies the most common tag and retrieves its description from the API definition. This enables meaningful grouping of related operations.

**`_getEndpointOperationName(endpoint)`**  
Uses the operation summary as the endpoint name, but only when the endpoint has exactly one operation. This prevents inappropriate use of single operation summaries for multi-operation endpoints.

### Name Resolution Priority

The component follows a clear hierarchy when determining endpoint display names:

- **Explicit endpoint name**: If the endpoint model includes a direct name property, use it
- **Tag-based naming**: Extract and use the most common tag from the endpoint's operations, including its description
- **Operation summary**: For single-operation endpoints, use the operation's summary
- **Path fallback**: When no other option is available, display the endpoint path

## Template Updates

### Endpoint with Name

When an endpoint has a resolved name (including from tags), the component displays:
- A paragraph containing the name (bold) and description (italic) if available
- The endpoint path as a clickable link below
<img width="1587" height="931" alt="Screenshot 2025-12-16 at 1 59 22 PM" src="https://github.com/user-attachments/assets/ae97648c-5df0-48d2-ab54-9bd8e7a6efce" />

### Endpoint without Name

When no name is resolved, the component displays only the endpoint path as before, maintaining backward compatibility.
<img width="649" height="854" alt="Screenshot 2025-12-16 at 1 59 43 PM" src="https://github.com/user-attachments/assets/16b493ac-b05a-4929-bc30-16855264eb9a" />

## Styling

**`.endpoint-name-description`**  
Container for the name and description block with controlled spacing and font size. Customizable via CSS custom properties.

**`.endpoint-name`**  
Bold text for the endpoint name with themeable color properties for consistency with the design system.

**`.endpoint-description`**  
Italic text for the tag description with subdued coloring to differentiate from the primary name.

## Testing

### Updated Existing Tests

Modified existing endpoint rendering tests to match the new HTML structure where endpoints display names separately from paths.

### New Test Suite: Tags-based Endpoint Grouping

Comprehensive test coverage for the tags-flights demo spec, validating:

- Correct number of endpoint groups rendered
- Tag names displayed accurately for each endpoint
- Tag descriptions shown when available
- Endpoint paths preserved and accessible
- Operation counts match the specification
- HTTP methods rendered correctly for each group

Tests run in both Full AMF model and Compact AMF model modes to ensure compatibility with both formats.

## Demo Integration

Added a new demo API specification `tags-flights.yml` showcasing the tag grouping feature with a flights API example. The demo includes two tag groups (AllFlights, OneFlight) with multiple operations demonstrating realistic usage patterns similar to what users would create in their own OpenAPI specifications.

## Backward Compatibility

Endpoints without tags or explicit names continue to display using their paths as before. The changes are additive and non-breaking for existing API specifications.

## Impact

This enhancement resolves the usability gap between API Console and other OpenAPI tools, allowing API designers to leverage tags for logical operation grouping as intended by the OpenAPI specification. Users can now see their APIs organized the same way across different tools, improving the overall developer experience.