### PR TITLE
[@W-21514384] fix(api-summary): resolve gRPC navigation when clicking nested span badges 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@api-components/api-summary",
-  "version": "4.6.18",
+  "version": "4.6.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@api-components/api-summary",
-      "version": "4.6.18",
+      "version": "4.6.19",
       "license": "Apache-2.0",
       "dependencies": {
         "@advanced-rest-client/arc-marked": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-summary",
   "description": "A summary view for an API base on AMF data model",
-  "version": "4.6.18",
+  "version": "4.6.19",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/src/ApiSummary.js
+++ b/src/ApiSummary.js
@@ -604,8 +604,15 @@ export class ApiSummary extends AmfHelperMixin(LitElement) {
 
   _navigateItem(e) {
     e.preventDefault();
-    const data = e.composedPath()[0].dataset;
-    if (!data.id || !data.shapeType) {
+    const path = e.composedPath();
+    let data;
+    for (const el of path) {
+      if (el.dataset && el.dataset.id && el.dataset.shapeType) {
+        data = el.dataset;
+        break;
+      }
+    }
+    if (!data) {
       return;
     }
     const ev = new CustomEvent("api-navigation-selection-changed", {

--- a/test/api-summary.test.js
+++ b/test/api-summary.test.js
@@ -797,6 +797,40 @@ describe('ApiSummary', () => {
           });
         }
       });
+
+      it('fires api-navigation-selection-changed when clicking gRPC span badge', async () => {
+        const span = element.shadowRoot.querySelector('.method-label.grpc-container .grpc-stream-type');
+        assert.exists(span, 'Should have a grpc-stream-type span inside grpc-container anchor');
+
+        let firedEvent = null;
+        element.addEventListener('api-navigation-selection-changed', (ev) => {
+          firedEvent = ev;
+        });
+
+        span.click();
+        await nextFrame();
+
+        assert.ok(firedEvent, 'api-navigation-selection-changed should have been fired');
+        assert.ok(firedEvent.detail.selected, 'Event detail should contain selected id');
+        assert.equal(firedEvent.detail.type, 'method', 'Event detail type should be "method"');
+      });
+
+      it('fires api-navigation-selection-changed when clicking gRPC anchor directly', async () => {
+        const anchor = element.shadowRoot.querySelector('.method-label.grpc-container');
+        assert.exists(anchor, 'Should have a grpc-container anchor');
+
+        let firedEvent = null;
+        element.addEventListener('api-navigation-selection-changed', (ev) => {
+          firedEvent = ev;
+        });
+
+        anchor.click();
+        await nextFrame();
+
+        assert.ok(firedEvent, 'api-navigation-selection-changed should have been fired');
+        assert.ok(firedEvent.detail.selected, 'Event detail should contain selected id');
+        assert.equal(firedEvent.detail.type, 'method', 'Event detail type should be "method"');
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes gRPC method badge clicks not triggering navigation in the API summary TOC.

- **Root cause**: `_navigateItem` was reading `e.composedPath()[0]` (the deepest element clicked). For gRPC methods, the `<a>` contains a child `<span class="grpc-stream-type">`, so clicking the badge returned the span — which has no `data-id` — and the handler silently exited.
- **Fix**: Walk `composedPath()` until finding the first element with both `data-id` and `data-shape-type`, instead of assuming the first element always has them.
- REST method navigation is unaffected (anchor is still the first element with dataset for REST).

## Changes

- `src/ApiSummary.js` — `_navigateItem`: walk composedPath to find data-bearing ancestor
- `test/api-summary.test.js` — 2 new regression tests in the gRPC suite:
  - Click on `.grpc-stream-type` span → event fires with correct `id` and `type: "method"`
  - Click directly on `.method-label.grpc-container` anchor → still works
- `package.json` — version bump `4.6.18 → 4.6.19`

## Test plan

- [x] `npm test` passes (125 tests, 0 failures, 95.62% coverage)
- [x] New test: clicking gRPC span badge fires `api-navigation-selection-changed`
- [x] New test: clicking gRPC anchor directly still fires the event
- [ ] Manual: load a gRPC API in the demo, click Unary/Bidirectional badges → navigates to method docs
- [ ] Manual: REST method badges still navigate correctly

Test in API Console

https://github.com/user-attachments/assets/92a5406e-c1c9-441f-9975-2097970fb0b4



## GUS

[W-21514384](https://gus.lightning.force.com/a07EE00002Vz65MYAR)