### PR TITLE
@W-23748890 feat(query): add QUERY method color badge (OAS 3.2)

### DIFF
--- a/demo/apis.json
+++ b/demo/apis.json
@@ -20,5 +20,6 @@
   "APIC-711/APIC-711.raml": "RAML 1.0",
   "agents-api/agents-api.yaml": { "type": "OAS 3.0", "mime": "application/yaml" },
   "tags-flights/tags-flights.yml": { "type": "OAS 3.0", "mime": "application/yaml" },
+  "oas32-query/oas32-query.yaml": { "type": "OAS 3.2", "mime": "application/yaml" },
   "grpc-test.json": { "type": "gRPC", "mime": "application/json" }
 }

--- a/demo/index.js
+++ b/demo/index.js
@@ -30,8 +30,7 @@ class ApiDemo extends ApiDemoPage {
       ["async-api", "AsyncAPI"],
       ["APIC-641", "APIC-641"],
       ["W-10881270", "W-10881270"],
-      ["async-api26", "AsyncAPI26"],
-      ["asyncApi-2.62", "AsyncAPI26-2"],
+      ["oas32-query", "OAS 3.2 (QUERY)"],
     ].map(
       ([file, label]) => html`
         <anypoint-item data-src="${file}-compact.json">${label}</anypoint-item>

--- a/demo/oas32-query/oas32-query.yaml
+++ b/demo/oas32-query/oas32-query.yaml
@@ -1,0 +1,57 @@
+openapi: 3.2.0
+info:
+  title: OAS 3.2 QUERY method
+  version: 1.0.0
+paths:
+  /pets:
+    # `query` is a Path Item Object fixed field in OAS 3.2 (sibling to get/post).
+    # amf-client-js 5.11 parses it as a real operation whose method is "QUERY"
+    # (upper case). `get` is included for contrast (method "get", lower case).
+    # COPY and MOVE are NOT included: amf-client-js 5.11 rejects them in an
+    # OAS 3.2 pathItem, so they can only be exercised via an inline AMF model
+    # (see the COPY/MOVE test).
+    get:
+      operationId: listPets
+      summary: List pets
+      responses:
+        "200":
+          description: A list of pets
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: integer
+                    name:
+                      type: string
+    query:
+      operationId: queryPets
+      summary: Search pets using a structured filter body
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                kind:
+                  type: string
+                maxAge:
+                  type: integer
+      responses:
+        "200":
+          description: Matching pets
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: integer
+                    name:
+                      type: string

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@api-components/api-summary",
-  "version": "4.6.19",
+  "version": "4.6.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@api-components/api-summary",
-      "version": "4.6.19",
+      "version": "4.6.20",
       "license": "Apache-2.0",
       "dependencies": {
         "@advanced-rest-client/arc-marked": "^1.1.2",
@@ -635,9 +635,9 @@
       }
     },
     "node_modules/@api-components/amf-helper-mixin": {
-      "version": "4.5.36",
-      "resolved": "https://registry.npmjs.org/@api-components/amf-helper-mixin/-/amf-helper-mixin-4.5.36.tgz",
-      "integrity": "sha512-Be+dnEatLXTaxQkQRJC79/+OZ+TwMe1QtMZP9AzdlBqtxrIx/6SnddluhTe4Zs48cA/B8yQNPKbBZAxb2mCCVA==",
+      "version": "4.5.38",
+      "resolved": "https://registry.npmjs.org/@api-components/amf-helper-mixin/-/amf-helper-mixin-4.5.38.tgz",
+      "integrity": "sha512-v1sWZ9MevGOllbVtHC19IZ1BlkHlSq4FUerAyoquc3pKLMGYg5h0HyGYsgYKDyi+HSAYJUcpPGAq7YqZC/2ZYQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "amf-json-ld-lib": "0.0.14"
@@ -744,9 +744,9 @@
       }
     },
     "node_modules/@api-components/api-navigation": {
-      "version": "4.3.21",
-      "resolved": "https://registry.npmjs.org/@api-components/api-navigation/-/api-navigation-4.3.21.tgz",
-      "integrity": "sha512-4N/mdmptSYU2owPz8YhXGFPFPAlnF7zdI07dKNKcGaipmaj0y5J5cjlWxJCcxdpUGNSxA/3K5GB6dcOCeN2xYA==",
+      "version": "4.3.24",
+      "resolved": "https://registry.npmjs.org/@api-components/api-navigation/-/api-navigation-4.3.24.tgz",
+      "integrity": "sha512-uhl5HG+DH0uWzIqupsO+X1bwRp5c9vQPNfT6pgBjRTmROrfK6RCrwr+SSOfCedbKJ+MsdAd4tgzlBi4vQ/KtrA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -754,7 +754,7 @@
         "@advanced-rest-client/icons": "^4.0.2",
         "@anypoint-web-components/anypoint-button": "^1.1.1",
         "@anypoint-web-components/anypoint-collapse": "^0.1.0",
-        "@api-components/amf-helper-mixin": "^4.5.34",
+        "@api-components/amf-helper-mixin": "^4.5.38",
         "@api-components/http-method-label": "^3.1.5",
         "@api-components/raml-aware": "^3.0.0",
         "lit-element": "^2.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@advanced-rest-client/markdown-styles": "^3.1.5",
         "@api-components/amf-helper-mixin": "^4.5.36",
         "@api-components/api-method-documentation": "^5.2.5",
-        "@api-components/api-model-generator": "^0.2.14",
+        "@api-components/api-model-generator": "^0.4.0",
         "@api-components/http-method-label": "^3.1.4",
         "@api-components/raml-aware": "^3.0.0",
         "dompurify": "^2.3.3",
@@ -377,6 +377,12 @@
       "license": "Apache-2.0",
       "peer": true
     },
+    "node_modules/@aml-org/amf-antlr-parsers": {
+      "version": "0.9.154",
+      "resolved": "https://registry.npmjs.org/@aml-org/amf-antlr-parsers/-/amf-antlr-parsers-0.9.154.tgz",
+      "integrity": "sha512-eXptBQVW/EuCiRAXl1qtOeMBQS9fFJKqMOH9b/PdvSAnIIFmrg/itqKsUdpnFRxFd0o9NYthbM/8Vc8sViBFQw==",
+      "license": "ISC"
+    },
     "node_modules/@anypoint-web-components/anypoint-autocomplete": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-autocomplete/-/anypoint-autocomplete-0.2.13.tgz",
@@ -725,12 +731,12 @@
       }
     },
     "node_modules/@api-components/api-model-generator": {
-      "version": "0.2.14",
-      "resolved": "https://registry.npmjs.org/@api-components/api-model-generator/-/api-model-generator-0.2.14.tgz",
-      "integrity": "sha512-HYOp0ScUpqETvx/l2NJ9gUaTzwy02oL9RRqTWDdL0BETcwfVQbpIhZPQ9c29LSwycNJZFOaoN6qRQiVqT+V3Wg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@api-components/api-model-generator/-/api-model-generator-0.4.0.tgz",
+      "integrity": "sha512-r/XlbF+A0DmxbqhmqSs+gX4T0n7RxLoag9hqIBo8a+kPZ99xO0NDXTFosqCZD4qD10tt2QDfWeU8BPgWOadOOw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "amf-client-js": "^4.7.6",
+        "amf-client-js": "5.11.12531",
         "fs-extra": "^10.0.0"
       },
       "engines": {
@@ -1197,15 +1203,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@colors/colors": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
-      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.1.90"
-      }
-    },
     "node_modules/@commitlint/cli": {
       "version": "18.6.1",
       "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-18.6.1.tgz",
@@ -1464,2242 +1461,6 @@
       },
       "engines": {
         "node": ">=v18"
-      }
-    },
-    "node_modules/@comunica/actor-abstract-bindings-hash": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-bindings-hash/-/actor-abstract-bindings-hash-1.22.0.tgz",
-      "integrity": "sha512-3Yrupl0AUFcPtxjImzvPSx6ygCgiJ4Ss0rFIhTuNRvTJohhYc/VpmPjqdprhghtHnhfmIEcqgb7TqdwqlntR2Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "canonicalize": "^1.0.1",
-        "hash.js": "^1.1.7",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-abstract-mediatyped": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-mediatyped/-/actor-abstract-mediatyped-1.22.0.tgz",
-      "integrity": "sha512-+KQLPpx8GFqrhWFfuvrsA4Rjlfbo/QOIo2IvzSgmDwy6YVQZXaSQiNQv/BnrnedaFCf2ONV+w+PMLqXgzn8N9A==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-abstract-path": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-path/-/actor-abstract-path-1.22.0.tgz",
-      "integrity": "sha512-S7IfWTKWvTTyRDiNb0NApLG1lwh3WKHmmBx6WqI3GicJfS+6kjZqrM2ke5OyVr2R6dpVfu6OnF0TiRYdPVgjEQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "rdf-data-factory": "^1.0.3",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-context-preprocess-source-to-destination": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-context-preprocess-source-to-destination/-/actor-context-preprocess-source-to-destination-1.22.0.tgz",
-      "integrity": "sha512-37aC7WacPIn7yObMubD3QvN0fze9kwBrHDf2M6cwe+54l3uCKYd8jeMH7pJTAT3eSLb32PYU1cxRiwRkQ8gVwQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/context-entries": "^1.22.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-context-preprocess": "^1.19.2",
-        "@comunica/core": "^1.19.2"
-      }
-    },
-    "node_modules/@comunica/actor-http-memento": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-http-memento/-/actor-http-memento-1.22.1.tgz",
-      "integrity": "sha512-H10dWC+RA/xkhORKBMUIw133PxKXmo8ByEeYgbV3QplyeZ5+Wv+0hh+Icil4rC5rsqcpW+iU2TZGK6vfsTQpMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/context-entries": "^1.22.0",
-        "@types/parse-link-header": "^1.0.0",
-        "cross-fetch": "^3.0.5",
-        "parse-link-header": "^1.0.1"
-      },
-      "peerDependencies": {
-        "@comunica/bus-http": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-http-native": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-http-native/-/actor-http-native-1.22.1.tgz",
-      "integrity": "sha512-BdB+hvQ9CJF9tI42hNhcvTMagOty+jw21LIQDJWI628xMcXZ88BJaUX0Ulc7g2nrWH97ZRm5+KjLC4Zf+OGwZg==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/context-entries": "^1.22.0",
-        "@types/parse-link-header": "^1.0.0",
-        "cross-fetch": "^3.0.5",
-        "follow-redirects": "^1.5.1",
-        "parse-link-header": "^1.0.1"
-      },
-      "peerDependencies": {
-        "@comunica/bus-http": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-http-node-fetch": {
-      "version": "1.22.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-http-node-fetch/-/actor-http-node-fetch-1.22.3.tgz",
-      "integrity": "sha512-e2J8g32QgwcbysOQkFDio757oaPLCGpSs7rRDoGq/daGS8l1m7Ugzhx7Vh3NHcCI3XXrymMOBzMT+ku5ddJbNg==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/context-entries": "^1.22.0",
-        "cross-fetch": "^3.0.5"
-      },
-      "peerDependencies": {
-        "@comunica/bus-http": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-http-proxy": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-http-proxy/-/actor-http-proxy-1.22.1.tgz",
-      "integrity": "sha512-q8Dil+MnKeZWKNxLLDXan070TUP+8io7zwwCs5apvaU26ghojBU4OOJx1vL6CInUjZCzTeyCYVPsBbvykjLZ2w==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@comunica/bus-http": "^1.8.0",
-        "@comunica/context-entries": "^1.0.0",
-        "@comunica/core": "^1.8.0"
-      }
-    },
-    "node_modules/@comunica/actor-init-sparql": {
-      "version": "1.22.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-init-sparql/-/actor-init-sparql-1.22.3.tgz",
-      "integrity": "sha512-rtD4ssn2JSrHHhpoHfvZoe4RpYkSZVuvWb2gh9Pu/sTo4wyIaCuRBc4Wn8N3ZnA4omBzv6/kM2NUF47eabmoBA==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/actor-abstract-bindings-hash": "^1.22.0",
-        "@comunica/actor-abstract-mediatyped": "^1.22.0",
-        "@comunica/actor-context-preprocess-source-to-destination": "^1.22.0",
-        "@comunica/actor-http-memento": "^1.22.1",
-        "@comunica/actor-http-native": "^1.22.1",
-        "@comunica/actor-http-node-fetch": "^1.22.3",
-        "@comunica/actor-http-proxy": "^1.22.1",
-        "@comunica/actor-optimize-query-operation-join-bgp": "^1.22.0",
-        "@comunica/actor-query-operation-ask": "^1.22.0",
-        "@comunica/actor-query-operation-bgp-empty": "^1.22.0",
-        "@comunica/actor-query-operation-bgp-left-deep-smallest": "^1.22.0",
-        "@comunica/actor-query-operation-bgp-single": "^1.22.0",
-        "@comunica/actor-query-operation-construct": "^1.22.0",
-        "@comunica/actor-query-operation-describe-subject": "^1.22.0",
-        "@comunica/actor-query-operation-distinct-hash": "^1.22.0",
-        "@comunica/actor-query-operation-extend": "^1.22.0",
-        "@comunica/actor-query-operation-filter-sparqlee": "^1.22.0",
-        "@comunica/actor-query-operation-from-quad": "^1.22.0",
-        "@comunica/actor-query-operation-group": "^1.22.0",
-        "@comunica/actor-query-operation-join": "^1.22.0",
-        "@comunica/actor-query-operation-leftjoin-left-deep": "^1.22.0",
-        "@comunica/actor-query-operation-leftjoin-nestedloop": "^1.22.0",
-        "@comunica/actor-query-operation-minus": "^1.22.0",
-        "@comunica/actor-query-operation-nop": "^1.22.0",
-        "@comunica/actor-query-operation-orderby-sparqlee": "^1.22.0",
-        "@comunica/actor-query-operation-path-alt": "^1.22.0",
-        "@comunica/actor-query-operation-path-inv": "^1.22.0",
-        "@comunica/actor-query-operation-path-link": "^1.22.0",
-        "@comunica/actor-query-operation-path-nps": "^1.22.0",
-        "@comunica/actor-query-operation-path-one-or-more": "^1.22.0",
-        "@comunica/actor-query-operation-path-seq": "^1.22.0",
-        "@comunica/actor-query-operation-path-zero-or-more": "^1.22.0",
-        "@comunica/actor-query-operation-path-zero-or-one": "^1.22.0",
-        "@comunica/actor-query-operation-project": "^1.22.0",
-        "@comunica/actor-query-operation-quadpattern": "^1.22.0",
-        "@comunica/actor-query-operation-reduced-hash": "^1.22.0",
-        "@comunica/actor-query-operation-service": "^1.22.3",
-        "@comunica/actor-query-operation-slice": "^1.22.0",
-        "@comunica/actor-query-operation-sparql-endpoint": "^1.22.2",
-        "@comunica/actor-query-operation-union": "^1.22.0",
-        "@comunica/actor-query-operation-update-add-rewrite": "^1.22.0",
-        "@comunica/actor-query-operation-update-clear": "^1.22.0",
-        "@comunica/actor-query-operation-update-compositeupdate": "^1.22.0",
-        "@comunica/actor-query-operation-update-copy-rewrite": "^1.22.0",
-        "@comunica/actor-query-operation-update-create": "^1.22.0",
-        "@comunica/actor-query-operation-update-deleteinsert": "^1.22.2",
-        "@comunica/actor-query-operation-update-drop": "^1.22.0",
-        "@comunica/actor-query-operation-update-load": "^1.22.0",
-        "@comunica/actor-query-operation-update-move-rewrite": "^1.22.0",
-        "@comunica/actor-query-operation-values": "^1.22.0",
-        "@comunica/actor-rdf-dereference-fallback": "^1.22.2",
-        "@comunica/actor-rdf-dereference-http-parse": "^1.22.3",
-        "@comunica/actor-rdf-join-multi-smallest": "^1.22.0",
-        "@comunica/actor-rdf-join-nestedloop": "^1.22.0",
-        "@comunica/actor-rdf-join-symmetrichash": "^1.22.0",
-        "@comunica/actor-rdf-metadata-all": "^1.22.0",
-        "@comunica/actor-rdf-metadata-extract-allow-http-methods": "^1.22.0",
-        "@comunica/actor-rdf-metadata-extract-hydra-controls": "^1.22.0",
-        "@comunica/actor-rdf-metadata-extract-hydra-count": "^1.22.0",
-        "@comunica/actor-rdf-metadata-extract-patch-sparql-update": "^1.22.2",
-        "@comunica/actor-rdf-metadata-extract-put-accepted": "^1.22.0",
-        "@comunica/actor-rdf-metadata-extract-sparql-service": "^1.22.0",
-        "@comunica/actor-rdf-metadata-primary-topic": "^1.22.0",
-        "@comunica/actor-rdf-parse-html": "^1.22.0",
-        "@comunica/actor-rdf-parse-html-microdata": "^1.22.0",
-        "@comunica/actor-rdf-parse-html-rdfa": "^1.22.0",
-        "@comunica/actor-rdf-parse-html-script": "^1.22.0",
-        "@comunica/actor-rdf-parse-jsonld": "^1.22.1",
-        "@comunica/actor-rdf-parse-n3": "^1.22.0",
-        "@comunica/actor-rdf-parse-rdfxml": "^1.22.0",
-        "@comunica/actor-rdf-parse-xml-rdfa": "^1.22.0",
-        "@comunica/actor-rdf-resolve-hypermedia-links-next": "^1.22.0",
-        "@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo": "^1.22.0",
-        "@comunica/actor-rdf-resolve-hypermedia-none": "^1.22.0",
-        "@comunica/actor-rdf-resolve-hypermedia-qpf": "^1.22.2",
-        "@comunica/actor-rdf-resolve-hypermedia-sparql": "^1.22.1",
-        "@comunica/actor-rdf-resolve-quad-pattern-federated": "^1.22.0",
-        "@comunica/actor-rdf-resolve-quad-pattern-hypermedia": "^1.22.2",
-        "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": "^1.22.0",
-        "@comunica/actor-rdf-serialize-jsonld": "^1.22.0",
-        "@comunica/actor-rdf-serialize-n3": "^1.22.0",
-        "@comunica/actor-rdf-update-hypermedia-patch-sparql-update": "^1.22.2",
-        "@comunica/actor-rdf-update-hypermedia-put-ldp": "^1.22.2",
-        "@comunica/actor-rdf-update-hypermedia-sparql": "^1.22.2",
-        "@comunica/actor-rdf-update-quads-hypermedia": "^1.22.2",
-        "@comunica/actor-rdf-update-quads-rdfjs-store": "^1.22.2",
-        "@comunica/actor-sparql-parse-algebra": "^1.22.0",
-        "@comunica/actor-sparql-parse-graphql": "^1.22.0",
-        "@comunica/actor-sparql-serialize-json": "^1.22.0",
-        "@comunica/actor-sparql-serialize-rdf": "^1.22.0",
-        "@comunica/actor-sparql-serialize-simple": "^1.22.0",
-        "@comunica/actor-sparql-serialize-sparql-csv": "^1.22.0",
-        "@comunica/actor-sparql-serialize-sparql-json": "^1.22.0",
-        "@comunica/actor-sparql-serialize-sparql-tsv": "^1.22.0",
-        "@comunica/actor-sparql-serialize-sparql-xml": "^1.22.0",
-        "@comunica/actor-sparql-serialize-stats": "^1.22.1",
-        "@comunica/actor-sparql-serialize-table": "^1.22.0",
-        "@comunica/actor-sparql-serialize-tree": "^1.22.0",
-        "@comunica/bus-context-preprocess": "^1.22.0",
-        "@comunica/bus-http": "^1.22.1",
-        "@comunica/bus-http-invalidate": "^1.22.0",
-        "@comunica/bus-init": "^1.22.0",
-        "@comunica/bus-optimize-query-operation": "^1.22.0",
-        "@comunica/bus-query-operation": "^1.22.0",
-        "@comunica/bus-rdf-dereference": "^1.22.2",
-        "@comunica/bus-rdf-dereference-paged": "^1.22.0",
-        "@comunica/bus-rdf-join": "^1.22.0",
-        "@comunica/bus-rdf-metadata": "^1.22.0",
-        "@comunica/bus-rdf-metadata-extract": "^1.22.0",
-        "@comunica/bus-rdf-parse": "^1.22.0",
-        "@comunica/bus-rdf-parse-html": "^1.22.0",
-        "@comunica/bus-rdf-resolve-hypermedia": "^1.22.0",
-        "@comunica/bus-rdf-resolve-hypermedia-links": "^1.22.0",
-        "@comunica/bus-rdf-resolve-hypermedia-links-queue": "^1.22.0",
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.22.0",
-        "@comunica/bus-rdf-serialize": "^1.22.0",
-        "@comunica/bus-rdf-update-hypermedia": "^1.22.2",
-        "@comunica/bus-rdf-update-quads": "^1.22.2",
-        "@comunica/bus-sparql-parse": "^1.22.0",
-        "@comunica/bus-sparql-serialize": "^1.22.0",
-        "@comunica/context-entries": "^1.22.0",
-        "@comunica/core": "^1.22.0",
-        "@comunica/logger-pretty": "^1.22.0",
-        "@comunica/logger-void": "^1.22.0",
-        "@comunica/mediator-all": "^1.22.0",
-        "@comunica/mediator-combine-pipeline": "^1.22.0",
-        "@comunica/mediator-combine-union": "^1.22.0",
-        "@comunica/mediator-number": "^1.22.0",
-        "@comunica/mediator-race": "^1.22.0",
-        "@comunica/runner": "^1.22.0",
-        "@comunica/runner-cli": "^1.22.0",
-        "@rdfjs/types": "*",
-        "@types/yargs": "^17.0.2",
-        "asynciterator": "^3.2.0",
-        "negotiate": "^1.0.1",
-        "rdf-quad": "^1.4.0",
-        "rdf-string": "^1.5.0",
-        "rdf-terms": "^1.6.2",
-        "sparqlalgebrajs": "^3.0.0",
-        "streamify-string": "^1.0.1",
-        "yargs": "^17.1.1"
-      },
-      "bin": {
-        "comunica-dynamic-sparql": "bin/query-dynamic.js",
-        "comunica-sparql": "bin/query.js",
-        "comunica-sparql-http": "bin/http.js"
-      }
-    },
-    "node_modules/@comunica/actor-init-sparql-rdfjs": {
-      "version": "1.22.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-init-sparql-rdfjs/-/actor-init-sparql-rdfjs-1.22.3.tgz",
-      "integrity": "sha512-twc9yf1nOCuCxuSYREODKRN1WJ2updEJ6Y5AllrY1VnBAiP1hWWJxn65KGjE6e9GDvfW1MTfPuXtqxlqIsDn8w==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/actor-abstract-mediatyped": "^1.22.0",
-        "@comunica/actor-init-sparql": "^1.22.3",
-        "@comunica/actor-query-operation-ask": "^1.22.0",
-        "@comunica/actor-query-operation-bgp-empty": "^1.22.0",
-        "@comunica/actor-query-operation-bgp-left-deep-smallest": "^1.22.0",
-        "@comunica/actor-query-operation-bgp-single": "^1.22.0",
-        "@comunica/actor-query-operation-construct": "^1.22.0",
-        "@comunica/actor-query-operation-describe-subject": "^1.22.0",
-        "@comunica/actor-query-operation-distinct-hash": "^1.22.0",
-        "@comunica/actor-query-operation-extend": "^1.22.0",
-        "@comunica/actor-query-operation-filter-sparqlee": "^1.22.0",
-        "@comunica/actor-query-operation-from-quad": "^1.22.0",
-        "@comunica/actor-query-operation-join": "^1.22.0",
-        "@comunica/actor-query-operation-leftjoin-nestedloop": "^1.22.0",
-        "@comunica/actor-query-operation-orderby-sparqlee": "^1.22.0",
-        "@comunica/actor-query-operation-path-alt": "^1.22.0",
-        "@comunica/actor-query-operation-path-inv": "^1.22.0",
-        "@comunica/actor-query-operation-path-link": "^1.22.0",
-        "@comunica/actor-query-operation-path-nps": "^1.22.0",
-        "@comunica/actor-query-operation-path-one-or-more": "^1.22.0",
-        "@comunica/actor-query-operation-path-seq": "^1.22.0",
-        "@comunica/actor-query-operation-path-zero-or-more": "^1.22.0",
-        "@comunica/actor-query-operation-path-zero-or-one": "^1.22.0",
-        "@comunica/actor-query-operation-project": "^1.22.0",
-        "@comunica/actor-query-operation-quadpattern": "^1.22.0",
-        "@comunica/actor-query-operation-service": "^1.22.3",
-        "@comunica/actor-query-operation-slice": "^1.22.0",
-        "@comunica/actor-query-operation-union": "^1.22.0",
-        "@comunica/actor-query-operation-values": "^1.22.0",
-        "@comunica/actor-rdf-join-nestedloop": "^1.22.0",
-        "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": "^1.22.0",
-        "@comunica/actor-rdf-serialize-jsonld": "^1.22.0",
-        "@comunica/actor-rdf-serialize-n3": "^1.22.0",
-        "@comunica/actor-sparql-parse-algebra": "^1.22.0",
-        "@comunica/actor-sparql-serialize-json": "^1.22.0",
-        "@comunica/actor-sparql-serialize-rdf": "^1.22.0",
-        "@comunica/actor-sparql-serialize-simple": "^1.22.0",
-        "@comunica/actor-sparql-serialize-sparql-json": "^1.22.0",
-        "@comunica/actor-sparql-serialize-sparql-xml": "^1.22.0",
-        "@comunica/bus-context-preprocess": "^1.22.0",
-        "@comunica/bus-init": "^1.22.0",
-        "@comunica/bus-query-operation": "^1.22.0",
-        "@comunica/bus-rdf-join": "^1.22.0",
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.22.0",
-        "@comunica/bus-rdf-serialize": "^1.22.0",
-        "@comunica/bus-sparql-parse": "^1.22.0",
-        "@comunica/bus-sparql-serialize": "^1.22.0",
-        "@comunica/core": "^1.22.0",
-        "@comunica/mediator-combine-pipeline": "^1.22.0",
-        "@comunica/mediator-combine-union": "^1.22.0",
-        "@comunica/mediator-number": "^1.22.0",
-        "@comunica/mediator-race": "^1.22.0",
-        "@comunica/runner": "^1.22.0",
-        "@comunica/runner-cli": "^1.22.0"
-      }
-    },
-    "node_modules/@comunica/actor-optimize-query-operation-join-bgp": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-join-bgp/-/actor-optimize-query-operation-join-bgp-1.22.0.tgz",
-      "integrity": "sha512-G0JSVM0q2kJb4X6p/zTyuMi4E5vdQsrJjx6Zy9FIG2EySAP+Q/M8TNSteJbyan07xZwxane6bZcCckvNyDVqTg==",
-      "license": "MIT",
-      "dependencies": {
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-optimize-query-operation": "^1.0.0",
-        "@comunica/core": "^1.4.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-ask": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-ask/-/actor-query-operation-ask-1.22.0.tgz",
-      "integrity": "sha512-kdByALpa1SM0PFlHarDQc6KjGXZ1xaTwvmhdldov7XN6KmXZyozic0qx29d5kNgMUsDOfaTbxPZFNmBRr32K0w==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-bgp-empty": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-empty/-/actor-query-operation-bgp-empty-1.22.0.tgz",
-      "integrity": "sha512-qitWhNrmehzvnNHZ98QuClOATyNRYte98OtR/C3trljMWjOrnC8pnstUHS5BN3bOBftRCBjO6ukJcnfgZFeNTQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "asynciterator": "^3.2.0",
-        "rdf-string": "^1.5.0",
-        "rdf-terms": "^1.6.2",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-bgp-left-deep-smallest": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-left-deep-smallest/-/actor-query-operation-bgp-left-deep-smallest-1.22.0.tgz",
-      "integrity": "sha512-c6u9knbOLh7W4JNGZh0Vc2dMCsDzm5/tjhhKttbvLuN8bGqvdx2Pxuv0beTyWSXhLXxeo6DkhtWAh/b+gtNBRw==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/context-entries": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "rdf-string": "^1.5.0",
-        "rdf-terms": "^1.6.2",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-bgp-single": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-single/-/actor-query-operation-bgp-single-1.22.0.tgz",
-      "integrity": "sha512-wxOO1Df9oRiAHUgZWx+o7zP+PZF/7kkHCueBWnvFA9Qqlw3naJLoFuAnhxSh1Ej4p5XGldjd1Bt/7VUFgfKOvQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/context-entries": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-construct": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-construct/-/actor-query-operation-construct-1.22.0.tgz",
-      "integrity": "sha512-URXw1bip+ZmBfcN6lksOMKfTOO7OuBZhJc09s6EiyBTfHbBxPmLEhkv/d/hzNiEf2D+LYHjmqRHq6gSh93g//g==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/data-factory": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "rdf-data-factory": "^1.0.3",
-        "rdf-terms": "^1.6.2",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-describe-subject": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-describe-subject/-/actor-query-operation-describe-subject-1.22.0.tgz",
-      "integrity": "sha512-DrBhicGLF00VYv6+QJ04tmKAn6nGQ0Yyih01K++yNfXByBL++1iXFrYwoLwQAJQZJ6H5FRLhYGMaB12mLq/wvQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/actor-query-operation-union": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "rdf-data-factory": "^1.0.3",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-distinct-hash": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-distinct-hash/-/actor-query-operation-distinct-hash-1.22.0.tgz",
-      "integrity": "sha512-6anXCszrUDoBZdOhLBmsBFxQR/P5tPsuzGFuXP+pf7zI9zIU6nfaMeffOj+GDPClReyXf1UmyJXsIKo7r5WWUg==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/actor-abstract-bindings-hash": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.0.0",
-        "@comunica/core": "^1.2.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-extend": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-extend/-/actor-query-operation-extend-1.22.0.tgz",
-      "integrity": "sha512-61AOM+62/Xtfd+5XtWiJUlcmK5oKQ2z77s5we2Z9AIrsxqKM90RdU9/t7U1g/3SrMiCMPNrN6mPfYiz7yG9pfA==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.2",
-        "sparqlee": "^1.10.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.4.0",
-        "@comunica/core": "^1.4.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-filter-sparqlee": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-filter-sparqlee/-/actor-query-operation-filter-sparqlee-1.22.0.tgz",
-      "integrity": "sha512-FceqE7qlPUADr3lbUbVKFL245IPNGS2OwFPIN6ksGPe1y/Cgd7f/lLpqmURxzpPELm76VgJQM5VzMOeDuwlt9Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "sparqlalgebrajs": "^3.0.0",
-        "sparqlee": "^1.10.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.4.0",
-        "@comunica/core": "^1.4.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-from-quad": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-from-quad/-/actor-query-operation-from-quad-1.22.0.tgz",
-      "integrity": "sha512-rkVS/YMOb50F7vo45jgvyErbiG17DDj0pSaaMo1Dm1XWohXOvXOMoJtE+x0iTISEbw8F+g/oPjUhns3VOR38hw==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-group": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-group/-/actor-query-operation-group-1.22.0.tgz",
-      "integrity": "sha512-EQCV/eFMTcplqwxcX0uR+cyaExrW0xIJPRJZkJpLX1mKYoeYh43FwYj6HQy00gwXImYYqFXw03lU0x+9P3dGLA==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/actor-abstract-bindings-hash": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "asynciterator": "^3.2.0",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0",
-        "sparqlee": "^1.10.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.6.0",
-        "@comunica/core": "^1.4.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-join": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-join/-/actor-query-operation-join-1.22.0.tgz",
-      "integrity": "sha512-QJBU4Vm438SGxqpV8g+vDg7IsETCfoHsl6GaZdFb8qT8EfSeIqd/oYAKJJMH/a6SzV5f8zRwDtXeWmDcA3fS1w==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.0.0",
-        "@comunica/bus-rdf-join": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-leftjoin-left-deep": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-leftjoin-left-deep/-/actor-query-operation-leftjoin-left-deep-1.22.0.tgz",
-      "integrity": "sha512-JetWHipImYLXffNVmSk0Q2f0CJYmO4UWjb1rixNtih2Plu10BWpwLICNhw6bnuco5LJb3/EdEmDBrWrkztXH6Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-rdf-join": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.9.3",
-        "@comunica/core": "^1.9.2"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-leftjoin-nestedloop": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-leftjoin-nestedloop/-/actor-query-operation-leftjoin-nestedloop-1.22.0.tgz",
-      "integrity": "sha512-NttPFDGr9vWJh5iYNz/xhLPTo7TEFc45D2UqAVa0bF2XyHSM0T+oVXKEZre+FqSxTxSxHUQ22vUXY9vctnO4Xg==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "asynciterator": "^3.2.0",
-        "sparqlalgebrajs": "^3.0.0",
-        "sparqlee": "^1.10.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.0.0",
-        "@comunica/bus-rdf-join": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-minus": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-minus/-/actor-query-operation-minus-1.22.0.tgz",
-      "integrity": "sha512-53f6V6XdypGu0aaFMHr6TcE1hOqoDHphNfd1OE/CRDbNfbK+ELz2pWTnGoWf6zGRW4srnCGA3Q5vtZpSNpOMHQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/actor-abstract-bindings-hash": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.2.0",
-        "@comunica/core": "^1.2.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-nop": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-nop/-/actor-query-operation-nop-1.22.0.tgz",
-      "integrity": "sha512-l0koSVdYIKisQHC6S31UIbxMdVau6G85gs3+sIYhKf1Ry+TivHM5Px2t1pfYfugS53+7cw4t87/q7mhgvh3GGQ==",
-      "license": "MIT",
-      "dependencies": {
-        "asynciterator": "^3.2.0",
-        "sparqlalgebrajs": "^3.0.1"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.21.1",
-        "@comunica/core": "^1.21.1"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-orderby-sparqlee": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-orderby-sparqlee/-/actor-query-operation-orderby-sparqlee-1.22.0.tgz",
-      "integrity": "sha512-5R4li6DxPvSrsr5oGi8hACmSBtARD/W6EzUhEiN7IRF1UjBMGMttKo/BrlcBKsolirWrPmvNsz9Y9eLSgcxx9Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0",
-        "sparqlee": "^1.10.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-path-alt": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-alt/-/actor-query-operation-path-alt-1.22.0.tgz",
-      "integrity": "sha512-mEDuira41HEcDdjCXcE9ofkDRD+mBOAKMKR6yl/C/xZdeC2ol/XltqbP7nZdxafgQ7rPCVAbsf0dyC2rU6uSNg==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/actor-abstract-path": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "asynciterator": "^3.2.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.2.0",
-        "@comunica/core": "^1.2.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-path-inv": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-inv/-/actor-query-operation-path-inv-1.22.0.tgz",
-      "integrity": "sha512-ZJnURpQ5JaxRR6Neh/Uea+bEVaeKFZCvVjMFxcPPelP/Xj7Bu7qSklhwwUCjgwvJafDYpdgvPNll9qV8QiQ8QA==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/actor-abstract-path": "^1.22.0",
-        "@comunica/types": "^1.22.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.2.0",
-        "@comunica/core": "^1.2.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-path-link": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-link/-/actor-query-operation-path-link-1.22.0.tgz",
-      "integrity": "sha512-xVqbgx8iF4YKgD4wf3CHBiTaOK+uj3IZsr/pB2xMUYL263tZCmRNF8xY9+pqnogb+7bOp2tvAn1lRXl7sydGrg==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/actor-abstract-path": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.2.0",
-        "@comunica/core": "^1.2.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-path-nps": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-nps/-/actor-query-operation-path-nps-1.22.0.tgz",
-      "integrity": "sha512-aBM44q3wjFz7J9nuPVEI0kpsFXcN14LK1bih8SwiUz8DMb+Ls4pODgWN00Y4PZgB6Aqf3NL9bRr/8UlheQZ56A==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/actor-abstract-path": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.2.0",
-        "@comunica/core": "^1.2.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-path-one-or-more": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-one-or-more/-/actor-query-operation-path-one-or-more-1.22.0.tgz",
-      "integrity": "sha512-lc8Qp9HhMwmhLI+PFpchmExFtivbDDR8EhFUsFt0LZuSLvmz4nH1wxrOLnL99/054RIisNyz7pYa+CzAsE5KUg==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/actor-abstract-path": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.2.0",
-        "@comunica/core": "^1.2.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-path-seq": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-seq/-/actor-query-operation-path-seq-1.22.0.tgz",
-      "integrity": "sha512-9oLdRJr9kDab0wzg75Ki54CxLkeU2lYMNGpPCj5AAtFXlXwCL3qiVnkNBjGdgyLLwg8hd6cQeOG12SYEcSfFDQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/actor-abstract-path": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.2.0",
-        "@comunica/core": "^1.2.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-path-zero-or-more": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-more/-/actor-query-operation-path-zero-or-more-1.22.0.tgz",
-      "integrity": "sha512-u9+v07ZxadcYiKTkrXW1GMiBAuS0Bi7N5Z1iPQSgD0HHC8p2JsNySteY4U9eSO5Y4lht8koeSGanplmCZY/YhA==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/actor-abstract-path": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "asynciterator": "^3.2.0",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.2.0",
-        "@comunica/core": "^1.2.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-path-zero-or-one": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-one/-/actor-query-operation-path-zero-or-one-1.22.0.tgz",
-      "integrity": "sha512-RnjN9y6oat2kZtYvcxBdyY29oDrO2ZH6sTwEDX4qro10QkfHm5Pa4SPGSoIdj5x1g5meeOOXisqKoZHQZUTJfA==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/actor-abstract-path": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "asynciterator": "^3.2.0",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.2.0",
-        "@comunica/core": "^1.2.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-project": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-project/-/actor-query-operation-project-1.22.0.tgz",
-      "integrity": "sha512-qjvpx4rto/CK/xefDn3232R0Ilc4DrhK5xl8RK7/l5Yn1/yFgWnqHK2sY+51O2/qeOkqYrb9ojoT9PwXHaLyXA==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/data-factory": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "rdf-data-factory": "^1.0.3",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-quadpattern": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-quadpattern/-/actor-query-operation-quadpattern-1.22.0.tgz",
-      "integrity": "sha512-kNNPhM28JCiJ/iYpobM+wv6Y71Q3adWTlt2GM1MF8ckU9Fa+IwdlFaZ9oYaLudLpPW48QtAXDLZgiNtZEhPNAg==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "rdf-string": "^1.5.0",
-        "rdf-terms": "^1.6.2",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.0.0",
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-reduced-hash": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-reduced-hash/-/actor-query-operation-reduced-hash-1.22.0.tgz",
-      "integrity": "sha512-vymsRgS+c4J48uzyvSIb/Qj1sJ1DEqRZXuQuw8KhCCzWmCRA49DPpx2lg2sc6PJJTjyQAU3xbqHVaZUyX5e9jQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/actor-abstract-bindings-hash": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "@types/lru-cache": "^5.1.0",
-        "lru-cache": "^6.0.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/actor-abstract-bindings-hash": "^1.2.0",
-        "@comunica/bus-query-operation": "^1.2.0",
-        "@comunica/core": "^1.2.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-reduced-hash/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-reduced-hash/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "license": "ISC"
-    },
-    "node_modules/@comunica/actor-query-operation-service": {
-      "version": "1.22.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-service/-/actor-query-operation-service-1.22.3.tgz",
-      "integrity": "sha512-z+UUJjgYppnZwV+Oz3ZVQBZpLxUAFrAtvpuVSUmjJn6ab76X29ZQY13czY2y6TfiBhbbsW+HL5kuv0g3SEOHug==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.22.0",
-        "@comunica/context-entries": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "asynciterator": "^3.2.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.2.0",
-        "@comunica/core": "^1.2.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-slice": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-slice/-/actor-query-operation-slice-1.22.0.tgz",
-      "integrity": "sha512-BjanWrGY2EgH8nm5aEsYCLQIt4FZRYU9lQECdpihmVCloGX1ItzR5Rfk51tnGbXBarqm+pj6WoT+zSu0Ee4x2A==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "asynciterator": "^3.2.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-sparql-endpoint": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-sparql-endpoint/-/actor-query-operation-sparql-endpoint-1.22.2.tgz",
-      "integrity": "sha512-y+bnQlhTUtlybstinINiayQVXro9lZfpBiVBM9zxyZOST/fwXho5alclasfFgwy04js8aIM1efx8eJD2OUwlxQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.22.0",
-        "@comunica/bus-rdf-update-quads": "^1.22.2",
-        "@comunica/types": "^1.22.0",
-        "@comunica/utils-datasource": "^1.22.2",
-        "@rdfjs/types": "*",
-        "arrayify-stream": "^1.0.0",
-        "asynciterator": "^3.2.0",
-        "fetch-sparql-endpoint": "^2.3.2",
-        "rdf-string": "^1.5.0",
-        "rdf-terms": "^1.6.2",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-http": "^1.2.0",
-        "@comunica/bus-query-operation": "^1.2.0",
-        "@comunica/core": "^1.2.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-union": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-union/-/actor-query-operation-union-1.22.0.tgz",
-      "integrity": "sha512-/qoweeCXg52ObfkFxjsU3nxsJBPavU6bCcDBJMLCFwd6VT9i7IKI+Y6aBH0CmCZpzBgaZQ1o3kGHJdUoxr+qyQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "asynciterator": "^3.2.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-update-add-rewrite": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-add-rewrite/-/actor-query-operation-update-add-rewrite-1.22.0.tgz",
-      "integrity": "sha512-4SBqqrsZBAwPJYoVr4w24D9NsAR48fQOUH6ZD05vyWG/vqedO2T2POFFNXBCCXiigr35QWvQLvbzoqamC5mbpg==",
-      "license": "MIT",
-      "dependencies": {
-        "rdf-data-factory": "^1.0.4",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.19.2",
-        "@comunica/core": "^1.19.2"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-update-clear": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-clear/-/actor-query-operation-update-clear-1.22.0.tgz",
-      "integrity": "sha512-qRrUrkQJjvLv6PysbVJ1vOndHIvCHXpp5CmP1GFU4SF7s0LT65PSWh6+LgmcLKs+bntVMbdqaBu58lR5jk7J7Q==",
-      "license": "MIT",
-      "dependencies": {
-        "rdf-data-factory": "^1.0.4"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.19.2",
-        "@comunica/core": "^1.19.2"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-update-compositeupdate": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-compositeupdate/-/actor-query-operation-update-compositeupdate-1.22.0.tgz",
-      "integrity": "sha512-rDt7JtQXOQ1LZY+xuhao6pv25zrXNH6VB8I6TlOAYm6OIE+PtAtbRp5AWzg8Yjqz81UHiXGQHV8SNx51LBkmtA==",
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.19.2",
-        "@comunica/core": "^1.19.2"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-update-copy-rewrite": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-copy-rewrite/-/actor-query-operation-update-copy-rewrite-1.22.0.tgz",
-      "integrity": "sha512-WYapkqUcVZ8KWfSUlEz8iBg+OoRnHI3XvAlx6cyql4Fs/3l0Gqwc2PzWHi3N5J2AUsyiFJ28JrGDba8f1PYGLg==",
-      "license": "MIT",
-      "dependencies": {
-        "rdf-data-factory": "^1.0.4",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.19.2",
-        "@comunica/core": "^1.19.2"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-update-create": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-create/-/actor-query-operation-update-create-1.22.0.tgz",
-      "integrity": "sha512-tZxqO+4n7qbDVJcp0VNYKRbI9uS8xTyK5s63sD53YeFl6Fl52dJtBb916R9Wb0pe2Pb37ErXF38/Z127P9EiNA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.19.2",
-        "@comunica/core": "^1.19.2"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-update-deleteinsert": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-deleteinsert/-/actor-query-operation-update-deleteinsert-1.22.2.tgz",
-      "integrity": "sha512-8VGwvEEjHoEVwTJXGW4USHLS5DKc5iZwn1NByTAg8YdgX8ycE2odJi766cR8GLkeZu6621OUyZIgSnLdSAuMvA==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/actor-query-operation-construct": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.19.2",
-        "@comunica/bus-rdf-update-quads": "^1.0.0",
-        "@comunica/core": "^1.19.2"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-update-drop": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-drop/-/actor-query-operation-update-drop-1.22.0.tgz",
-      "integrity": "sha512-5DuDEmUrUO5vktgiDIHtBJtv0k1mHQqCQyF4nKLctq2bTDPaaYK533jqPM+ucxXINryx6t4SowUgdVRqpn4VIA==",
-      "license": "MIT",
-      "dependencies": {
-        "rdf-data-factory": "^1.0.4"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.19.2",
-        "@comunica/core": "^1.19.2"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-update-load": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-load/-/actor-query-operation-update-load-1.22.0.tgz",
-      "integrity": "sha512-nI4fMNGUevmprlTBgbuovJMQl+1LabCajvjC9ri5hZ9Ya0fEVQsFNbXH7H2oYlC0OOzM6uUjTdb9I8D/OzF8+g==",
-      "license": "MIT",
-      "dependencies": {
-        "rdf-data-factory": "^1.0.4",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.19.2",
-        "@comunica/core": "^1.19.2"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-update-move-rewrite": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-move-rewrite/-/actor-query-operation-update-move-rewrite-1.22.0.tgz",
-      "integrity": "sha512-ulo9KDuUy7555C0aOdgMUgOvCTLszJy8zLzN67HKktu1wK6WKV10zVMX/OcecdFE4fIVf/AA4SKXJCgsHGpXsQ==",
-      "license": "MIT",
-      "dependencies": {
-        "rdf-data-factory": "^1.0.4",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.19.2",
-        "@comunica/core": "^1.19.2"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-values": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-values/-/actor-query-operation-values-1.22.0.tgz",
-      "integrity": "sha512-P6znlDSYd6aD6NlSepc++V5HbmnNE8O4vZ8nvNmwZAS4z/pWjkaFM6eQkZPdkz+qXaGTzWHS3ib2zUDq3CaD4w==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "asynciterator": "^3.2.0",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-dereference-fallback": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-dereference-fallback/-/actor-rdf-dereference-fallback-1.22.2.tgz",
-      "integrity": "sha512-EzvBerax4WVOxmkRuHviehUQ3VUU0CPHV+fErFB9+s5UbXHk6MU3GqzH9iehoFYzpP7Xic0VZXFd34nCTvzmtg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@comunica/bus-rdf-dereference": "^1.19.2",
-        "@comunica/core": "^1.19.2"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-dereference-http-parse": {
-      "version": "1.22.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-dereference-http-parse/-/actor-rdf-dereference-http-parse-1.22.3.tgz",
-      "integrity": "sha512-OBtJTHA8OXAWF3+FJ7n0R1i8nGzxD2xK18mgMPu4JId9r9bUS4RMKCDWa8MIG6p9Hd7SleuS9bC48w5vm07yww==",
-      "license": "MIT",
-      "dependencies": {
-        "cross-fetch": "^3.0.5",
-        "relative-to-absolute-iri": "^1.0.5",
-        "stream-to-string": "^1.2.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-http": "^1.0.0",
-        "@comunica/bus-rdf-dereference": "^1.0.0",
-        "@comunica/bus-rdf-parse": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-join-multi-smallest": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-multi-smallest/-/actor-rdf-join-multi-smallest-1.22.0.tgz",
-      "integrity": "sha512-eoMuumFT+GB73f7H8Q8ijzchqHRY26w20lcKcsylC2bWS+ET8tFkYCODHop0uO53DMZPCrAm0C1higPB4XOw7Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-query-operation": "^1.22.0",
-        "@comunica/mediatortype-iterations": "^1.22.0",
-        "@comunica/types": "^1.22.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-join": "^1.9.2",
-        "@comunica/core": "^1.9.2"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-join-nestedloop": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-nestedloop/-/actor-rdf-join-nestedloop-1.22.0.tgz",
-      "integrity": "sha512-8APKCtsH6lWmadCnp8xkJqu0O8uqBZ1GfFmV3KxmE3jPx9lrMVckmKBAd3i7vcMHWRwzOvZF4YFJkJxL7JeqnQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "asyncjoin": "^1.0.3"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-join": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-join-symmetrichash": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-symmetrichash/-/actor-rdf-join-symmetrichash-1.22.0.tgz",
-      "integrity": "sha512-+K11crWY5N+Txb5HOP8P5/z2EN7WK8Cq1o1Go2RkUHhR0Pc4HZMoJtf6ATyJGB64y3lRpUVzKayrqSkDXlaSbQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "asyncjoin": "^1.0.3"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-join": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-metadata-all": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-all/-/actor-rdf-metadata-all-1.22.0.tgz",
-      "integrity": "sha512-8I7xrelM3G5nJ8SB5sh/cuIniAF0uDQ4AH8LA9z+aZQI5RvHN4kfgW6V/9NSmaEskyscy9m+nGkByEpuh+pHvQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-metadata": "^1.6.3",
-        "@comunica/core": "^1.6.3"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-metadata-extract-allow-http-methods": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-allow-http-methods/-/actor-rdf-metadata-extract-allow-http-methods-1.22.0.tgz",
-      "integrity": "sha512-vbbJxxtDZ8KFOLTZ4/bbilI95Kj1u7eaQcOw15PWvsMz29e9Mi28Gvguv1m/7CIpn4myNEWWu9hkardzWGcFhg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@comunica/bus-rdf-metadata-extract": "^1.21.1",
-        "@comunica/core": "^1.21.1"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-metadata-extract-hydra-controls": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-hydra-controls/-/actor-rdf-metadata-extract-hydra-controls-1.22.0.tgz",
-      "integrity": "sha512-fSYye14RuiT0H9il92G8bDUuOrRxRY1is/+C+ShAXb6npx05GDfO+p9Ew4hBCRbveU10DAdsarOTYpcP2bTZSQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/uritemplate": "^0.3.4",
-        "uritemplate": "0.3.4"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-metadata-extract": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-metadata-extract-hydra-count": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-hydra-count/-/actor-rdf-metadata-extract-hydra-count-1.22.0.tgz",
-      "integrity": "sha512-IM27SyFT2lRZc853m10I8YQX+nzSS5ouY4dLWyI3yzlYfI1LFOI/kDiUicgiyAoAy7UBG2c60jvFXTC6HQsdJw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@comunica/bus-rdf-metadata-extract": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-metadata-extract-patch-sparql-update": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-patch-sparql-update/-/actor-rdf-metadata-extract-patch-sparql-update-1.22.2.tgz",
-      "integrity": "sha512-de9IJPIuXrvh8plhl8RndrbNcigO7hhi34bEoKwcjdX8YBK1F4BEK3mRvE0rlSjwv5vDLPjT4ejxl6bL2Da/rQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@comunica/bus-rdf-metadata-extract": "^1.20.0",
-        "@comunica/core": "^1.20.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-metadata-extract-put-accepted": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-put-accepted/-/actor-rdf-metadata-extract-put-accepted-1.22.0.tgz",
-      "integrity": "sha512-VLZQI1eEQOImxFgfa9grlB1AzmfZweypBodQlvHSESgqUhKzyEkaX00HiK2kM74vmccdCpzEEoOfwaJdXU8TbQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@comunica/bus-rdf-metadata-extract": "^1.21.1",
-        "@comunica/core": "^1.21.1"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-metadata-extract-sparql-service": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-sparql-service/-/actor-rdf-metadata-extract-sparql-service-1.22.0.tgz",
-      "integrity": "sha512-z2w/bhFZ/iWq7KgdLqBD/8CWL7S9VZJSmczccgKmwQGRJWzJ4mHpUAdOCh7EFD/9HbsC4fXJGXZHQjZ8u6SM6g==",
-      "license": "MIT",
-      "dependencies": {
-        "relative-to-absolute-iri": "^1.0.5"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-metadata-extract": "^1.8.0",
-        "@comunica/core": "^1.8.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-metadata-primary-topic": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-primary-topic/-/actor-rdf-metadata-primary-topic-1.22.0.tgz",
-      "integrity": "sha512-+ZRSUVDqUZo5RLwOUbtIifiBn2Qgg6awMsfRlw2PeGE72BhQ1ik0tfz1l9Q7UuYnxnLoUFe2zyKEYc7GXAV34g==",
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-metadata": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-parse-html": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html/-/actor-rdf-parse-html-1.22.0.tgz",
-      "integrity": "sha512-U9pznSpQ1POSH+ekOke3lYKO0fsUbNdv1g1nfuWz/MV3xMCF/d2f3CVBjXRSx9qwyb/2zUrOjBCJRrYkfZ6geQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-rdf-parse-html": "^1.22.0",
-        "@rdfjs/types": "*",
-        "htmlparser2": "^7.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-parse": "^1.8.0",
-        "@comunica/core": "^1.8.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-parse-html-microdata": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-microdata/-/actor-rdf-parse-html-microdata-1.22.0.tgz",
-      "integrity": "sha512-OdB3Z7ZCtVAcsVU2Vs0ytGbiz0eYkeBwVA3k0vGVhSN3ygng5Thj+t8jxG6QWHlLvaIXfJFh0x57qY5tXkr8uQ==",
-      "license": "MIT",
-      "dependencies": {
-        "microdata-rdf-streaming-parser": "^1.2.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-parse-html": "^1.17.0",
-        "@comunica/core": "^1.17.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-parse-html-rdfa": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-rdfa/-/actor-rdf-parse-html-rdfa-1.22.0.tgz",
-      "integrity": "sha512-yVjYLpm9rbpPiqU1OE4Yioyk/YHtO6ywVMbdOPUNLeOwrtWou8vKX0Xh4UUR24Qrt8nuhE+p0kCJiZZtM1PmSQ==",
-      "license": "MIT",
-      "dependencies": {
-        "rdfa-streaming-parser": "^1.5.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-parse-html": "^1.0.0",
-        "@comunica/core": "^1.8.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-parse-html-script": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-script/-/actor-rdf-parse-html-script-1.22.0.tgz",
-      "integrity": "sha512-gQSY56wkS/uftRyjQf+/dQFRpA/jZ6z2o2RgGbQc2avgKTkhaiTtPxpfO1oarLskm1sPlQOFo24ZwqUSqjOwcA==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-rdf-parse-html": "^1.22.0",
-        "@rdfjs/types": "*",
-        "relative-to-absolute-iri": "^1.0.5"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-parse": "^1.4.0",
-        "@comunica/core": "^1.4.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-parse-jsonld": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-jsonld/-/actor-rdf-parse-jsonld-1.22.1.tgz",
-      "integrity": "sha512-MFFhJ6eGyO40Be80zsFKAbRjkPXr80PvCqvVKsEstdv3u9C6GFV3nqZpCwvsVCz22IPQhW+rzb8ZyasmgHnurA==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/context-entries": "^1.22.0",
-        "@rdfjs/types": "*",
-        "jsonld-context-parser": "^2.1.2",
-        "jsonld-streaming-parser": "^2.4.0",
-        "stream-to-string": "^1.2.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-http": "^1.0.0",
-        "@comunica/bus-rdf-parse": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-parse-n3": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-n3/-/actor-rdf-parse-n3-1.22.0.tgz",
-      "integrity": "sha512-qHrGfh5k/pZa4imy7m9gJ1kt9aW1uxXqLDKnLKvR2l0m09YiEx/YOYWr1Wtu1YtH/Yyc13OX4mo/OwaE5PfrHQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/n3": "^1.4.4",
-        "n3": "^1.6.3"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-parse": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-parse-rdfxml": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-rdfxml/-/actor-rdf-parse-rdfxml-1.22.0.tgz",
-      "integrity": "sha512-k47WEAZ6qKEhf1eBZZeI5aVywlrUUKP3BKHw2zKJUjuWq5k+w/rp2WALCyt0Owtb37UlJbET3fTlUhXKvT+2aw==",
-      "license": "MIT",
-      "dependencies": {
-        "rdfxml-streaming-parser": "^1.5.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-parse": "^1.1.0",
-        "@comunica/core": "^1.1.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-parse-xml-rdfa": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-xml-rdfa/-/actor-rdf-parse-xml-rdfa-1.22.0.tgz",
-      "integrity": "sha512-y315YcZTz7AizKf8Jl022IocAJIh3OHSlzNrRNH3zB7i/ch+WHj1VL9pjIf6y77PD4BR75EdeoQCPafpm5Gsbg==",
-      "license": "MIT",
-      "dependencies": {
-        "rdfa-streaming-parser": "^1.5.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-parse": "^1.8.0",
-        "@comunica/core": "^1.8.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-resolve-hypermedia-links-next": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-links-next/-/actor-rdf-resolve-hypermedia-links-next-1.22.0.tgz",
-      "integrity": "sha512-94t3u2B2kH8ftMtkLfo1B/v1SJkiFdEf3y351UOqrWJ71GNMQwgvzQFcSRL4QRcgaIjz4wecj8oGUN0wPs2Kdg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@comunica/bus-rdf-resolve-hypermedia-links": "^1.0.0",
-        "@comunica/core": "^1.8.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo/-/actor-rdf-resolve-hypermedia-links-queue-fifo-1.22.0.tgz",
-      "integrity": "sha512-DzQgHFDDXtawPvNbei1j6xL2yWdlSpq/vOD4K8Z+NrheKjNbPz84bJp0bhnWiOonwHMCRdxQRu+Etf33SFWFJQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@comunica/bus-rdf-resolve-hypermedia-links": "^1.19.2",
-        "@comunica/bus-rdf-resolve-hypermedia-links-queue": "^1.0.0",
-        "@comunica/core": "^1.19.2"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-resolve-hypermedia-none": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-none/-/actor-rdf-resolve-hypermedia-none-1.22.0.tgz",
-      "integrity": "sha512-rPtjD7WAlXBwrWmG5vy9hGo5J9AlKaWuH7Cf3I0HFUnPRegF98UAFZyygQP4otDC3EsygJakbmApBkzjiKFRPw==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": "^1.22.0",
-        "@rdfjs/types": "*",
-        "rdf-store-stream": "^1.3.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-resolve-hypermedia": "^1.8.0",
-        "@comunica/core": "^1.8.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-resolve-hypermedia-qpf": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-qpf/-/actor-rdf-resolve-hypermedia-qpf-1.22.2.tgz",
-      "integrity": "sha512-dHR6FtLj/buvHmOT9B0FysWwIQO7L0+uqCnHQ9peShKOwpKMtl5qW9a8L63yWNlB34JgB+ZvL0/qJO7JWZZXTQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-rdf-dereference": "^1.22.2",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "rdf-data-factory": "^1.0.3",
-        "rdf-string": "^1.5.0",
-        "rdf-terms": "^1.6.2"
-      },
-      "peerDependencies": {
-        "@comunica/actor-rdf-metadata-extract-hydra-controls": "^1.0.0",
-        "@comunica/bus-rdf-metadata": "^1.0.0",
-        "@comunica/bus-rdf-metadata-extract": "^1.0.0",
-        "@comunica/bus-rdf-resolve-hypermedia": "^1.0.0",
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-resolve-hypermedia-sparql": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-sparql/-/actor-rdf-resolve-hypermedia-sparql-1.22.1.tgz",
-      "integrity": "sha512-nbvGfhHKyPBygeQyxLyUyrQen7q3JrSJi92x8TrkhUoTxiEYM0bYUvYmsciqlxLhNxH7EPpMzzf1oaiZfiqlqA==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-query-operation": "^1.22.0",
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "fetch-sparql-endpoint": "^2.3.2",
-        "rdf-data-factory": "^1.0.3",
-        "rdf-terms": "^1.6.2",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-resolve-hypermedia": "^1.8.0",
-        "@comunica/core": "^1.8.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-resolve-quad-pattern-federated": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-federated/-/actor-rdf-resolve-quad-pattern-federated-1.22.0.tgz",
-      "integrity": "sha512-Cpt5LvusDUK/mnA2LlcuQ3hqpJp9CSDjd0c7NESWuR2uCXDAxugWVJAll0EosIAw0Lx82n0SneOBqh6pk2gPxQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/context-entries": "^1.22.0",
-        "@comunica/data-factory": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "rdf-data-factory": "^1.0.3",
-        "rdf-terms": "^1.6.2",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-resolve-quad-pattern-hypermedia": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-hypermedia/-/actor-rdf-resolve-quad-pattern-hypermedia-1.22.2.tgz",
-      "integrity": "sha512-eQhXoOYVpEJNkp6pYvJwaU+PmvR41VEKX9zivcBxRGagbLOaX5SG0xV+0I2YApB4HvagD/0IICVRRxXqODRUVA==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo": "^1.22.0",
-        "@comunica/bus-rdf-metadata": "^1.22.0",
-        "@comunica/bus-rdf-metadata-extract": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "@comunica/utils-datasource": "^1.22.2",
-        "@rdfjs/types": "*",
-        "@types/lru-cache": "^5.1.0",
-        "asynciterator": "^3.2.0",
-        "lru-cache": "^6.0.0",
-        "rdf-data-factory": "^1.0.3",
-        "rdf-string": "^1.5.0",
-        "rdf-terms": "^1.6.2",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/actor-rdf-metadata-extract-hydra-controls": "^1.0.0",
-        "@comunica/bus-http-invalidate": "^1.0.0",
-        "@comunica/bus-rdf-dereference": "^1.0.0",
-        "@comunica/bus-rdf-resolve-hypermedia": "^1.0.0",
-        "@comunica/bus-rdf-resolve-hypermedia-links": "^1.0.0",
-        "@comunica/bus-rdf-resolve-hypermedia-links-queue": "^1.0.0",
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-resolve-quad-pattern-hypermedia/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-resolve-quad-pattern-hypermedia/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "license": "ISC"
-    },
-    "node_modules/@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source/-/actor-rdf-resolve-quad-pattern-rdfjs-source-1.22.0.tgz",
-      "integrity": "sha512-iy7PQav5pytbtHfU7EjP9NTKRXEKNez7tZfoI6FwGVIreX0WrxpE100xCjhQt0kkkEb7l0R0Yn6n9cXsJc8Gcg==",
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.2.0",
-        "@comunica/core": "^1.2.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-serialize-jsonld": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-jsonld/-/actor-rdf-serialize-jsonld-1.22.0.tgz",
-      "integrity": "sha512-UrkVEkeY2Oobsjw0kiswtTNcJU9ePXlekFE0iyemZs7b3DLAibzQeMERTiY2lSV+NBwpGhKAR+6DkCjLjd/TOA==",
-      "license": "MIT",
-      "dependencies": {
-        "jsonld-streaming-serializer": "^1.3.0"
-      },
-      "peerDependencies": {
-        "@comunica/actor-abstract-mediatyped": "^1.0.0",
-        "@comunica/bus-rdf-serialize": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-serialize-n3": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-n3/-/actor-rdf-serialize-n3-1.22.0.tgz",
-      "integrity": "sha512-9LBLd+ayFn7Rb/ASt1ZrBjjsUZV9I01E7MB19mcz3pyCt1HZdQ0l8JeZ5gC18cOK5B/X1KKZsx2wP+ZpHwa/og==",
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/n3": "^1.4.4",
-        "n3": "^1.6.3",
-        "rdf-string": "^1.5.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-serialize": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-update-hypermedia-patch-sparql-update": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-hypermedia-patch-sparql-update/-/actor-rdf-update-hypermedia-patch-sparql-update-1.22.2.tgz",
-      "integrity": "sha512-CqaDel2GTxYcM9CVzMERaGlA6XVWbqjkAfvnufhl9suMiDw8aqnuw91sPMbTlh38MhAaLY6SVwmxqekmdtxOhg==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-rdf-update-quads": "^1.22.2",
-        "cross-fetch": "^3.0.5",
-        "rdf-string-ttl": "^1.1.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-http": "^1.0.0",
-        "@comunica/bus-rdf-update-hypermedia": "^1.0.0",
-        "@comunica/core": "^1.0.0",
-        "@comunica/types": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-update-hypermedia-put-ldp": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-hypermedia-put-ldp/-/actor-rdf-update-hypermedia-put-ldp-1.22.2.tgz",
-      "integrity": "sha512-SucEQhDSA5Tul7+RNWKaKuRMiNZS9zzBo92lJH1VSOx9SY9nnOcTVieNJrA8p3ExyYivnLmufe4AAM7M/m/T1g==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-rdf-update-quads": "^1.22.2",
-        "cross-fetch": "^3.0.5"
-      },
-      "peerDependencies": {
-        "@comunica/bus-http": "^1.0.0",
-        "@comunica/bus-rdf-serialize": "^1.0.0",
-        "@comunica/bus-rdf-update-hypermedia": "^1.0.0",
-        "@comunica/core": "^1.0.0",
-        "@comunica/types": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-update-hypermedia-sparql": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-hypermedia-sparql/-/actor-rdf-update-hypermedia-sparql-1.22.2.tgz",
-      "integrity": "sha512-wtA5ZRqWdPH3lIjouCavTmfbNzLxP4QhmlR4SXeefgICf5bSP/2J7/UMBZHHpEmuQhrvqbKYRJGNzQSCzzd9vA==",
-      "license": "MIT",
-      "dependencies": {
-        "fetch-sparql-endpoint": "^2.3.2",
-        "rdf-string-ttl": "^1.1.0",
-        "stream-to-string": "^1.2.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-http": "^1.0.0",
-        "@comunica/bus-rdf-update-hypermedia": "^1.21.1",
-        "@comunica/core": "^1.21.1"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-update-quads-hypermedia": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-quads-hypermedia/-/actor-rdf-update-quads-hypermedia-1.22.2.tgz",
-      "integrity": "sha512-e6kbJTIo92ig4LxdgQTGHcXp3PjHjdWWqOpVDO6Um5S/hoYRWZLA5/KI9BAxIodyaMaYU+gfSymkVfSNPrJjmw==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-rdf-dereference": "^1.22.2",
-        "@comunica/bus-rdf-metadata": "^1.22.0",
-        "@comunica/bus-rdf-metadata-extract": "^1.22.0",
-        "@comunica/bus-rdf-update-hypermedia": "^1.22.2",
-        "@types/lru-cache": "^5.1.0",
-        "lru-cache": "^6.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-http-invalidate": "^1.20.0",
-        "@comunica/bus-rdf-update-quads": "^1.20.0",
-        "@comunica/core": "^1.20.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-update-quads-hypermedia/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-update-quads-hypermedia/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "license": "ISC"
-    },
-    "node_modules/@comunica/actor-rdf-update-quads-rdfjs-store": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-quads-rdfjs-store/-/actor-rdf-update-quads-rdfjs-store-1.22.2.tgz",
-      "integrity": "sha512-veMjUWILDYzsvETvlGjFN14w5zNTAZlbFr7vmm6F4zuI5m5G4wnVHrdhU1cf7wp3foGVDOzp5jIC9Hl3UMKtCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "rdf-data-factory": "^1.0.4",
-        "rdf-string": "^1.5.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-update-quads": "^1.0.0",
-        "@comunica/core": "^1.19.2"
-      }
-    },
-    "node_modules/@comunica/actor-sparql-parse-algebra": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-parse-algebra/-/actor-sparql-parse-algebra-1.22.0.tgz",
-      "integrity": "sha512-8XdAbj0zd2O+2dE/i+J/mdL6xAK8qYcQ6xFf61SmIPIQBxdSRmlqxKfIc+qdCp8/KyEEG/ePA6+nG0rb94nqfw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/sparqljs": "^3.0.0",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0",
-        "sparqljs": "^3.4.1"
-      },
-      "peerDependencies": {
-        "@comunica/bus-sparql-parse": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-sparql-parse-graphql": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-parse-graphql/-/actor-sparql-parse-graphql-1.22.0.tgz",
-      "integrity": "sha512-tbN2Vh1y+XwvkKP+6Pshq89Enr/aWmG9qJH7WKdu25GqJRN9yydk3NVHJBwGpesydtRKlgFN/UrYuM7FCls8MQ==",
-      "license": "MIT",
-      "dependencies": {
-        "graphql-to-sparql": "^2.4.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-sparql-parse": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-sparql-serialize-json": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-json/-/actor-sparql-serialize-json-1.22.0.tgz",
-      "integrity": "sha512-DFFBGoQxvGHtE6t9/5vsIABUakFLok1l4FSx97fhQ3551+LiosWBbjFpswFwEr0AGKHJPEDH4qYe0gvVuUqq+w==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "rdf-string": "^1.5.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-sparql-serialize": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-sparql-serialize-rdf": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-rdf/-/actor-sparql-serialize-rdf-1.22.0.tgz",
-      "integrity": "sha512-OMe31+egTtd7aSTi1bu3ufsNXjJDNPQ/5glxGCzPb0ZxC+lE4LMdGtMZ3mpfLy8mzEQCrMXGZboCyv1K7I9EAw==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/types": "^1.22.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-serialize": "^1.0.0",
-        "@comunica/bus-sparql-serialize": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-sparql-serialize-simple": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-simple/-/actor-sparql-serialize-simple-1.22.0.tgz",
-      "integrity": "sha512-wkoQz+xyd7FA00C0T70ochP3UOW4TrYpxBLbnqPkm7Iw8pFEn1iJ8ta12SNuju/lVtqfN+e16CFD0OlaGgCEZA==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*"
-      },
-      "peerDependencies": {
-        "@comunica/bus-sparql-serialize": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-sparql-serialize-sparql-csv": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-sparql-csv/-/actor-sparql-serialize-sparql-csv-1.22.0.tgz",
-      "integrity": "sha512-dXlNRulCZRCtf+GamYrBsR4bAbLZvcFPZp1WsbuGhCygqitu2QLwTlSMphgOtyuOCPEeF8Y6+1yljqoTC58WMA==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-query-operation": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*"
-      },
-      "peerDependencies": {
-        "@comunica/bus-sparql-serialize": "^1.15.0",
-        "@comunica/core": "^1.15.0"
-      }
-    },
-    "node_modules/@comunica/actor-sparql-serialize-sparql-json": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-sparql-json/-/actor-sparql-serialize-sparql-json-1.22.0.tgz",
-      "integrity": "sha512-bFQX/a/lAv4akO7/8xMM/lbr2ZZbSPb4byo4TlSDLihnOeB8sEXb8hBPHqHoN57faxUUqzBEy4zzx4cdcXHM4g==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*"
-      },
-      "peerDependencies": {
-        "@comunica/bus-sparql-serialize": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-sparql-serialize-sparql-tsv": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-sparql-tsv/-/actor-sparql-serialize-sparql-tsv-1.22.0.tgz",
-      "integrity": "sha512-a/zZDura9tu0g6wP/Z1+/RUT1zKJICjeC5azOX6BOSTdt6N+ldNrB06tyRyIbPyAGSAK0t+tOgiUPWanjXXUng==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-query-operation": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "rdf-string-ttl": "^1.1.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-sparql-serialize": "^1.15.0",
-        "@comunica/core": "^1.15.0"
-      }
-    },
-    "node_modules/@comunica/actor-sparql-serialize-sparql-xml": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-sparql-xml/-/actor-sparql-serialize-sparql-xml-1.22.0.tgz",
-      "integrity": "sha512-vADmIcOg2A+d4MRRjp/nm1yxpRjCB1nJKaGlXgqmEfkRYKbxrhv0/WzByF6OqdrR3W3ZMTKwzAsNdo4+mWQVRQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "@types/xml": "^1.0.2",
-        "xml": "^1.0.1"
-      },
-      "peerDependencies": {
-        "@comunica/bus-sparql-serialize": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-sparql-serialize-stats": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-stats/-/actor-sparql-serialize-stats-1.22.1.tgz",
-      "integrity": "sha512-v8OzTGRZNlh86f8C24WA3IIf8XfHQBMWJIxQsFsGeVj3jtB2ngYM7GZtr/xvcRjHooTULygcQIE4wwkW+KMlCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*"
-      },
-      "peerDependencies": {
-        "@comunica/bus-http": "^1.10.0",
-        "@comunica/bus-sparql-serialize": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-sparql-serialize-table": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-table/-/actor-sparql-serialize-table-1.22.0.tgz",
-      "integrity": "sha512-Vh8PGLHGNBnqtzqwdLAekQuneetmrpcXIdTaC+CSpjbGLamsXTfvzkPJCi4TgdxWnEmRcjMGo8MMyho0A+cToA==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "rdf-terms": "^1.6.2"
-      },
-      "peerDependencies": {
-        "@comunica/bus-sparql-serialize": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-sparql-serialize-tree": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-tree/-/actor-sparql-serialize-tree-1.22.0.tgz",
-      "integrity": "sha512-ICC1jTz++ThLXjXVIbrPJvfibu1DL9eTlPpooX3P70n8RQyG80f1SBAxdn4M42Q1+YE8poRjJx1ZgxVoQ8Rnag==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "sparqljson-to-tree": "^2.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-sparql-serialize": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/bus-context-preprocess": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-context-preprocess/-/bus-context-preprocess-1.22.0.tgz",
-      "integrity": "sha512-N4Lmu8JovfhDBOuyhG/7Gaig4v+nWFYbrhCRpj5gSnbn4J8WwqNmcbwVWWi3jCgw/SGsk3QRIQaFXyS3IigydQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/bus-http": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-http/-/bus-http-1.22.1.tgz",
-      "integrity": "sha512-CZ0NDWZH0k0FOshuRQJzYr3Z+2ZM1vqr9ZepONuaoYDwyKaxl29xPs3hNfjSy6YawjEQP+elr/WDc3TxKIpu8g==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/context-entries": "^1.22.0",
-        "@types/readable-stream": "^2.3.11",
-        "is-stream": "^2.0.0",
-        "readable-web-to-node-stream": "^3.0.2",
-        "web-streams-node": "^0.4.0"
-      },
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/bus-http-invalidate": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-http-invalidate/-/bus-http-invalidate-1.22.0.tgz",
-      "integrity": "sha512-JQnEvU9s+Q/OBUdKEbI15QPyO4d7opkGi1nGah9aMpFx7o3CuIa62SuzmDokfgHXOIVaOh2e6gWDNuFjCj9cBA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@comunica/core": "^1.4.0"
-      }
-    },
-    "node_modules/@comunica/bus-init": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-init/-/bus-init-1.22.0.tgz",
-      "integrity": "sha512-NIfEJLI8EYFdTWJB0PV/lxPagStPl+gUj3LtOnovcF1ZhC5rgcJSC/tq1r04n0TziY2KVangnLDsF4752LjD6g==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/bus-optimize-query-operation": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-optimize-query-operation/-/bus-optimize-query-operation-1.22.0.tgz",
-      "integrity": "sha512-psRjzvqYdohXIM9AYRDawe0axJM8S1RfeRWsbi+f4z18axEDMq/FEBRkmbpCoZaQ2DR2a16RcUr0ItgchWHUJQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/core": "^1.4.0"
-      }
-    },
-    "node_modules/@comunica/bus-query-operation": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-query-operation/-/bus-query-operation-1.22.0.tgz",
-      "integrity": "sha512-4qRytLHR+1ghNsct9+OArnXDPQt8/PGTwLsseI7ACZ0Q8Ao1Oq212nNshC5Vl90bueh20iksHfBFBogttzsTDA==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/context-entries": "^1.22.0",
-        "@comunica/data-factory": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "immutable": "^3.8.2",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/bus-rdf-dereference": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-dereference/-/bus-rdf-dereference-1.22.2.tgz",
-      "integrity": "sha512-dtLEmCzlscpe8AqEver8H+7a7UzyOXslUQ00VE+igt/+oAQvJpRBCQ3yB6XkyjAV/+ApLrbAjpCRf3Gp2NWfgg==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/context-entries": "^1.22.0",
-        "@rdfjs/types": "*"
-      },
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/bus-rdf-dereference-paged": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-dereference-paged/-/bus-rdf-dereference-paged-1.22.0.tgz",
-      "integrity": "sha512-UMjrL8VXP5gMcESAOqMq/yhaK6MlFRPtewcG7hpOEkCKUaR2Ss3N7caGCkBc3c2aLvCjuD3aZXiiRfR+JuzRRA==",
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0"
-      },
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/bus-rdf-join": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-join/-/bus-rdf-join-1.22.0.tgz",
-      "integrity": "sha512-kxxoOnSgMCEIhU1ToSnucT1nv6ktoPwTPr3uVt/q36873WdCnfUGgd1yAMGQfTQWQbOf9BlL2dYHmJkzPvx78A==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0"
-      },
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/bus-rdf-metadata": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata/-/bus-rdf-metadata-1.22.0.tgz",
-      "integrity": "sha512-d/eHq4ofHDll2c9SFQkxGFg8rwsezOQJ5vktGEaic1k57297ke4tEG4JB0MdgZCUNwLieAtEtB81qj0mqW1WaA==",
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*"
-      },
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/bus-rdf-metadata-extract": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata-extract/-/bus-rdf-metadata-extract-1.22.0.tgz",
-      "integrity": "sha512-u7YXAKh3jXbPBE1ATciwwdYjwi8BNDi6hkRYxszD+IKJeW6x62VXiw24sraR3mvJohl3a2tR9nQHWv9Khijisg==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "graphql-ld": "^1.4.0",
-        "rdf-store-stream": "^1.3.0",
-        "sparqlalgebrajs": "^3.0.0",
-        "stream-to-string": "^1.2.0"
-      },
-      "peerDependencies": {
-        "@comunica/actor-init-sparql": "^1.16.2",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/bus-rdf-parse": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse/-/bus-rdf-parse-1.22.0.tgz",
-      "integrity": "sha512-ohZGlabX5K+dEmn+v4BzP+IZVyRc1ovWItHDLznnRqsHQr8W19WPG21lEFh5kk2MK4YnyQWmlUax1Yxrg7cbXg==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/actor-abstract-mediatyped": "^1.22.0",
-        "@rdfjs/types": "*"
-      },
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/bus-rdf-parse-html": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse-html/-/bus-rdf-parse-html-1.22.0.tgz",
-      "integrity": "sha512-zqdLdF5qvru1vnzN4t9eXpJhi6khKm1ZWhUovBB9pfYnnyGRCQCPlFpcgJPrD8JfKd6nTvhgdLB5QcAbBb1I0A==",
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*"
-      },
-      "peerDependencies": {
-        "@comunica/core": "^1.8.0"
-      }
-    },
-    "node_modules/@comunica/bus-rdf-resolve-hypermedia": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-hypermedia/-/bus-rdf-resolve-hypermedia-1.22.0.tgz",
-      "integrity": "sha512-stZUCKUOkt7DCwgSZdhY6tFiUEj4sbkjroJg6BfA3ATJptH7waINPn1D0ytrg0NHy1+vuU+5H1E6/Qtlczuk0g==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0"
-      },
-      "peerDependencies": {
-        "@comunica/actor-rdf-metadata-extract-hydra-controls": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/bus-rdf-resolve-hypermedia-links": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-hypermedia-links/-/bus-rdf-resolve-hypermedia-links-1.22.0.tgz",
-      "integrity": "sha512-w76L61DC/7PchmONzf7wYuMlN08TWN9Vr+ulse84/4+jResEYzCji5kYJV4AiAKQ868ufwuGJuskf6FJlUjqFg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@comunica/core": "^1.8.0"
-      }
-    },
-    "node_modules/@comunica/bus-rdf-resolve-hypermedia-links-queue": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-hypermedia-links-queue/-/bus-rdf-resolve-hypermedia-links-queue-1.22.0.tgz",
-      "integrity": "sha512-2l+AEDwEIGD19ogk3umDuV25h0xMpHCMliefK8aL3iUqw1LzY93aHx7A2BgidfdQKrWog6R+vkazTaL/duTX2w==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@comunica/core": "^1.19.2"
-      }
-    },
-    "node_modules/@comunica/bus-rdf-resolve-quad-pattern": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-quad-pattern/-/bus-rdf-resolve-quad-pattern-1.22.0.tgz",
-      "integrity": "sha512-Re3hM8mwqbPNuS23Uh0GvMI+ryC6gWMrC+johCWhDOX+iYqLv1bUgfrC0tZE4v7reMyYp6nuCVHa/9o+F3Fweg==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/context-entries": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/bus-rdf-serialize": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-serialize/-/bus-rdf-serialize-1.22.0.tgz",
-      "integrity": "sha512-GY07qx6IIfM2GoIa8Vm8rq+iU2d/r7T6fBX61ZJxAsNKrbhtniuaqMrdZ2CL6sYKSBxVTNeRzP2l+d55So8v2Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/actor-abstract-mediatyped": "^1.22.0",
-        "@rdfjs/types": "*"
-      },
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/bus-rdf-update-hypermedia": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-update-hypermedia/-/bus-rdf-update-hypermedia-1.22.2.tgz",
-      "integrity": "sha512-pvTEAKDgpCuUcR+JK/8VbuhiL1WYBMe9nyWdHZrrVhQC6hJMKB6Gmrly3qc8JKVk8iPmpYyAT4Ea29DxEIl6HQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-rdf-update-quads": "^1.22.2"
-      },
-      "peerDependencies": {
-        "@comunica/core": "^1.20.0"
-      }
-    },
-    "node_modules/@comunica/bus-rdf-update-quads": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-update-quads/-/bus-rdf-update-quads-1.22.2.tgz",
-      "integrity": "sha512-MnczplJyAwZrfPAMfORKG+U8xdTxUbdKUcbopOk82JJvN3AjiDrbBetp3eS+Q+O+wV4Ae0kzrng+Q1aJ3zpiRA==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-http": "^1.22.1",
-        "@comunica/context-entries": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "stream-to-string": "^1.2.0"
-      },
-      "peerDependencies": {
-        "@comunica/core": "^1.19.2"
-      }
-    },
-    "node_modules/@comunica/bus-sparql-parse": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-sparql-parse/-/bus-sparql-parse-1.22.0.tgz",
-      "integrity": "sha512-3xnsbh5wfiCuFPMa2RHzzIIBkwVRUEdao4iydzlp3mTJjU5huWSyL6zvteIm/lIjW0HbWCQY5QfQ1FiAyZB6lA==",
-      "license": "MIT",
-      "dependencies": {
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/bus-sparql-serialize": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-sparql-serialize/-/bus-sparql-serialize-1.22.0.tgz",
-      "integrity": "sha512-qBlhEkEwtScGLrlebu2YqWbyAR/765zNtxqQqUBfEXaf+3ahmSACpwKFMuxJh0v7VXWCQNKYTA5WfFlEz7V4Uw==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/actor-abstract-mediatyped": "^1.22.0",
-        "@comunica/types": "^1.22.0"
-      },
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/context-entries": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/context-entries/-/context-entries-1.22.0.tgz",
-      "integrity": "sha512-HOYr1HdhgavxABpw8saZa9pueLAeGVVd/6cZ3FWcYnH3CvfQu6Ima06Gd00QdIAiGjQm01qQcWCxp0xURiqLKg==",
-      "license": "MIT"
-    },
-    "node_modules/@comunica/core": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-1.22.0.tgz",
-      "integrity": "sha512-tgozygRFTd6t6l0YyvfVUWNC+KXWiTlBclkxtzFioQsplKvUSvg1TPjopRk8hhAvMaNRGMNBK2ZafNaqNTkI4w==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/context-entries": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "immutable": "^3.8.2"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
-    "node_modules/@comunica/data-factory": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/data-factory/-/data-factory-1.22.0.tgz",
-      "integrity": "sha512-t18NJMdB6n/CjhNKIfofTkAL2YClj842se8utnk2sfCis9OIdUW8EuRfR9iyFHmVFdfe2RjEeKBPd6iye5Ns3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
-    "node_modules/@comunica/logger-pretty": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/logger-pretty/-/logger-pretty-1.22.0.tgz",
-      "integrity": "sha512-YCCRDIvbhWAygEqADnKnbCt7jnR4AasnoukLOQKyv1JAYxEV61FqReGG2LMtCqYR4VWUAa9tr51Ov+vOH1cMBg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/logger-void": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/logger-void/-/logger-void-1.22.0.tgz",
-      "integrity": "sha512-ORLVmoE47wqWZGdNKcZ8wpnEHtfcUKGhnDt5KbS/YV2qv4m/dG9eNIn6ax5FZeX2EFDSzWtlvMYNxNFhTvb7VQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/mediator-all": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-all/-/mediator-all-1.22.0.tgz",
-      "integrity": "sha512-jr+tYDDDJuVeW20yauB6GH3Xov0I9eW1y0V69hgcFgyi2xTBN1z+X7OkLjOBVFzYJnHmpr+rLvpxkZIiYcOW/w==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@comunica/core": "^1.4.0"
-      }
-    },
-    "node_modules/@comunica/mediator-combine-pipeline": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-pipeline/-/mediator-combine-pipeline-1.22.0.tgz",
-      "integrity": "sha512-SSXOvup8vlw1tS60RICXO3N+pK+7OzpwFmw5VuIVfliIdzAklEBoMUy4BucxlyX64Pgvt6nUXvaSvY3JGf9GXw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/mediator-combine-union": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-union/-/mediator-combine-union-1.22.0.tgz",
-      "integrity": "sha512-iUHmEGgWVmk02e80uB7w8xZ5vgTLpiqzrImvbokolJzWcVbobVCUkq8DUxzz3FJbNVRGipZUFrOqkRPAuAX6FA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/mediator-number": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-number/-/mediator-number-1.22.0.tgz",
-      "integrity": "sha512-KDPlJEvj0Lu+JygGXjnH8pf33k01lJ+wgzUlWK216jZJ1Px2lTlfc/COhSqi/e0y+k4ZSBcxx0gnjt2awMpbrQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/mediator-race": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-race/-/mediator-race-1.22.0.tgz",
-      "integrity": "sha512-hIMaHyf9M4jOS0199OURSVgWFmzkyF2K2keuAb+iHoCH3UUcUnWjPOL1TrdkxvaUnrxmsBWR9SXbnqgMnhIsiQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/mediatortype-iterations": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/mediatortype-iterations/-/mediatortype-iterations-1.22.0.tgz",
-      "integrity": "sha512-pN8aCGSh19FFu2IHjXJdCib2ewhOuW+DzQVkGTG0oD472amqQAlBVNxR38QParVP/ra70Isnbp+mfFlFLHrkYg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/runner": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/runner/-/runner-1.22.0.tgz",
-      "integrity": "sha512-U2coGGD2n/fmu6zOGPBXAvsG/pjJ3agblX0bxpRvspsZdScE/8N+5rDil1lacIayAn/JE2g4oRZgI4WZ4ZicvA==",
-      "license": "MIT",
-      "dependencies": {
-        "componentsjs": "^4.0.6"
-      },
-      "bin": {
-        "comunica-compile-config": "bin/compile-config"
-      },
-      "peerDependencies": {
-        "@comunica/bus-init": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/runner-cli": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/runner-cli/-/runner-cli-1.22.0.tgz",
-      "integrity": "sha512-bkMMOJKv5zEilxgFNmVIE4SX0xNDUUoHn4J/fEakhbGtLkhmrKSKlVTU4lv3opIn3yM9jZXxyJgda1DmZMld+Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/runner": "^1.22.0"
-      },
-      "bin": {
-        "comunica-run": "bin/run.js"
-      }
-    },
-    "node_modules/@comunica/types": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@comunica/types/-/types-1.22.0.tgz",
-      "integrity": "sha512-ZQ8p+ZvMAKmdq6Hz2QwqIQ2JScwRMotiWz0iSw2zYHsYQOhVmLg7HSMzMHpWNEA5UWzO/A5A+Co/ONXMhlnx3g==",
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "immutable": "^3.8.2",
-        "sparqlalgebrajs": "^3.0.1"
-      }
-    },
-    "node_modules/@comunica/utils-datasource": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/@comunica/utils-datasource/-/utils-datasource-1.22.2.tgz",
-      "integrity": "sha512-f4md6ydlNu/0lCrcts0T+Rqwbyx68IdmCvyd8DChg/hWlVqKbrKW8RKPzYhIN7kyF/+IDqg0a0KVpoaaD1mBYw==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.22.0",
-        "@comunica/bus-rdf-update-quads": "^1.22.2",
-        "@comunica/context-entries": "^1.22.0",
-        "asynciterator": "^3.2.0"
-      },
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@dabh/diagnostics": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.8.tgz",
-      "integrity": "sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@so-ric/colorspace": "^1.1.6",
-        "enabled": "2.0.x",
-        "kuler": "^2.0.0"
       }
     },
     "node_modules/@emmetio/extract-abbreviation": {
@@ -4255,15 +2016,6 @@
         "prismjs": "^1.11.0"
       }
     },
-    "node_modules/@rdfjs/types": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-2.0.1.tgz",
-      "integrity": "sha512-uyAzpugX7KekAXAHq26m3JlUIZJOC0uSBhpnefGV5i15bevDyyejoB7I+9MKeUrzXD8OOUI3+4FeV1wwQr5ihA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@rollup/plugin-node-resolve": {
       "version": "13.3.0",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.3.0.tgz",
@@ -4358,16 +2110,6 @@
       "integrity": "sha512-DE427ROAphMQzU4ENbliGYrBSYPXF+TtLg9S8vzeA+OF4ZKzoDdzfL8sxuMUGS/lgRhM6j1URSk9ghf7Xo1tyA==",
       "dev": true,
       "license": "(Unlicense OR Apache-2.0)"
-    },
-    "node_modules/@so-ric/colorspace": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@so-ric/colorspace/-/colorspace-1.1.6.tgz",
-      "integrity": "sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==",
-      "license": "MIT",
-      "dependencies": {
-        "color": "^5.0.2",
-        "text-hex": "1.0.x"
-      }
     },
     "node_modules/@thepassle/axobject-query": {
       "version": "4.0.0",
@@ -4532,15 +2274,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/http-link-header": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@types/http-link-header/-/http-link-header-1.0.7.tgz",
-      "integrity": "sha512-snm5oLckop0K3cTDAiBnZDy6ncx9DJ3mCRDvs42C884MbVYPP74Tiq2hFsSDRTyjK6RyDYDIulPiW23ge+g5Lw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -4609,16 +2342,11 @@
         "@types/koa": "*"
       }
     },
-    "node_modules/@types/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw==",
-      "license": "MIT"
-    },
     "node_modules/@types/minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/mocha": {
@@ -4628,20 +2356,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/n3": {
-      "version": "1.26.1",
-      "resolved": "https://registry.npmjs.org/@types/n3/-/n3-1.26.1.tgz",
-      "integrity": "sha512-TilYHzpU6ecXVJAbV+6o17Z8ZkWLWx6ZJD3IluaU4RiGHxqjU2or9fopxFHS6iXS6qcl5Mg1K3wSx9L8xxJaJQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/node": {
       "version": "25.1.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.1.0.tgz",
       "integrity": "sha512-t7frlewr6+cbx+9Ohpl0NOTKXZNV9xHRmNOvql47BFJKcEG1CxtxlPEEe+gR9uhVWM4DwhnvTF110mIL4yP9RA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -4659,12 +2378,6 @@
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
       "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/parse-link-header": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@types/parse-link-header/-/parse-link-header-1.0.1.tgz",
-      "integrity": "sha512-E2+Go9rQgPbmpkeA2iFXTWSTxX38KXlXwcdiIbt71Oorqr+G5QtH4AhpuDdxwRVyiTzdUrHnaaIumW/LhiZwVg==",
       "license": "MIT"
     },
     "node_modules/@types/parse5": {
@@ -4688,16 +2401,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/readable-stream": {
-      "version": "2.3.15",
-      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-2.3.15.tgz",
-      "integrity": "sha512-oM5JSKQCcICF1wvGgmecmHldZ48OZamtMxcGGVICOJA8o8cahXC1zEVAif8iwoc5j8etxFaRFnf095+CDsuoFQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "safe-buffer": "~5.1.1"
-      }
-    },
     "node_modules/@types/resolve": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
@@ -4707,12 +2410,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
-      "license": "MIT"
     },
     "node_modules/@types/send": {
       "version": "1.2.1",
@@ -4763,39 +2460,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/spark-md5": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@types/spark-md5/-/spark-md5-3.0.5.tgz",
-      "integrity": "sha512-lWf05dnD42DLVKQJZrDHtWFidcLrHuip01CtnC2/S6AMhX4t9ZlEUj4iuRlAnts0PQk7KESOqKxeGE/b6sIPGg==",
-      "license": "MIT"
-    },
-    "node_modules/@types/sparqljs": {
-      "version": "3.1.12",
-      "resolved": "https://registry.npmjs.org/@types/sparqljs/-/sparqljs-3.1.12.tgz",
-      "integrity": "sha512-zg/sdKKtYI0845wKPSuSgunyU1o/+7tRzMw85lHsf4p/0UbA6+65MXAyEtv1nkaqSqrq/bXm7+bqXas+Xo5dpQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": ">=1.0.0"
-      }
-    },
-    "node_modules/@types/triple-beam": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
-      "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
-      "license": "MIT"
-    },
-    "node_modules/@types/uritemplate": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@types/uritemplate/-/uritemplate-0.3.6.tgz",
-      "integrity": "sha512-31BMGZ8GgLxgXxLnqg4KbbyYJjU1flhTTD2+PVQStVUPXSk0IIpK0zt+tH3eLT7ZRwLnzQw6JhYx69qza3U0wg==",
-      "license": "MIT"
-    },
-    "node_modules/@types/uuid": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
-      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
-      "license": "MIT"
-    },
     "node_modules/@types/ws": {
       "version": "7.4.7",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.7.tgz",
@@ -4805,30 +2469,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/xml": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@types/xml/-/xml-1.0.11.tgz",
-      "integrity": "sha512-9gktTjxBWoz4+X8ZOS+QRFM2/liMQgBv8Z36wuNnomK5jtXFq4IJa7Az4Hzoy+rYux343NkH9Dq+nzIdejVrjw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/yargs": {
-      "version": "17.0.35",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
-      "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/yargs-parser": "*"
-      }
-    },
-    "node_modules/@types/yargs-parser": {
-      "version": "21.0.3",
-      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
-      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
-      "license": "MIT"
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
@@ -5466,7 +3106,9 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "event-target-shim": "^5.0.0"
       },
@@ -5584,10 +3226,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-      "dev": true,
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -5598,6 +3239,23 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/amdefine": {
@@ -5612,39 +3270,19 @@
       }
     },
     "node_modules/amf-client-js": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/amf-client-js/-/amf-client-js-4.7.8.tgz",
-      "integrity": "sha512-Wd6USEvxelx6DAzyILciPEWPmNRDkhN2ldBY0F8n5HrTjfRNvY/jEkV/pF/pj/WnLKtDI3cbMkMK2kzQOyF6fA==",
+      "version": "5.11.12531",
+      "resolved": "https://registry.npmjs.org/amf-client-js/-/amf-client-js-5.11.12531.tgz",
+      "integrity": "sha512-zAc/PwsOfsNzgii7LAsuJrYx+qXUBlOkd3Mwz3YD9r+jZjpJkEeDmxtb+N4F+Z5dy/g3i6J0kMfgeVYWCUOwtA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "ajv": "6.12.6",
-        "amf-shacl-node": "2.0.0"
+        "@aml-org/amf-antlr-parsers": "0.9.154",
+        "ajv": "8.20.0",
+        "ajv-formats": "3.0.1",
+        "avro-js": "1.11.5"
       },
       "bin": {
         "amf": "bin/amf"
       }
-    },
-    "node_modules/amf-client-js/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/amf-client-js/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "license": "MIT"
     },
     "node_modules/amf-json-ld-lib": {
       "version": "0.0.14",
@@ -5655,36 +3293,6 @@
         "node": ">=12.16.0",
         "npm": ">=6.13.4"
       }
-    },
-    "node_modules/amf-shacl-node": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/amf-shacl-node/-/amf-shacl-node-2.0.0.tgz",
-      "integrity": "sha512-38GcUBN7VFzpJHDWeEKZ5bcosGA1/Ur6egUrno+Uprgf/8aXeX0LumkG64sExQPrFQ649Ku3wfgWe+le4bUNVw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@comunica/actor-init-sparql-rdfjs": "^1.10.0",
-        "jsonld-streaming-serializer": "^1.1.0",
-        "lru-cache": "^6.0.0",
-        "n3": "^1.3.5"
-      }
-    },
-    "node_modules/amf-shacl-node/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/amf-shacl-node/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "license": "ISC"
     },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
@@ -5729,6 +3337,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5738,6 +3347,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -5960,12 +3570,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/arrayify-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/arrayify-stream/-/arrayify-stream-1.0.0.tgz",
-      "integrity": "sha512-RP80ep76Lbew2wWN5ogrl2NluTnBVYYh2K3NNCcWfcmmUB7nBcNBctiJeEZAixp3I1vQ9H88iHZ9MbHSdkuupQ==",
-      "license": "MIT"
-    },
     "node_modules/arrify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
@@ -6011,6 +3615,7 @@
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/async-function": {
@@ -6021,24 +3626,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/asynciterator": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/asynciterator/-/asynciterator-3.10.0.tgz",
-      "integrity": "sha512-eDOBoUf2m+4ht0ETVn2SCfuBIZZ6UWyyQbP++LRPKoK7PmrCQq37pJ6vRvyef4o1Pn+CwWnzMlkXxGdh/krVIw==",
-      "license": "MIT",
-      "dependencies": {
-        "tiny-set-immediate": "^1.0.2"
-      }
-    },
-    "node_modules/asyncjoin": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/asyncjoin/-/asyncjoin-1.2.4.tgz",
-      "integrity": "sha512-7/1g5uV2/iTDQteJ/pxqZq6qkO5406V+vNyOCYtHJ+mo6bmvvQHHrZgd7AtU/rx+cnz08NPWlwk8daW61thnlA==",
-      "license": "MIT",
-      "dependencies": {
-        "asynciterator": "^3.9.0"
       }
     },
     "node_modules/attempt-x": {
@@ -6066,6 +3653,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/avro-js": {
+      "version": "1.11.5",
+      "resolved": "https://registry.npmjs.org/avro-js/-/avro-js-1.11.5.tgz",
+      "integrity": "sha512-oevfVBGmLFF8CgUXnrw50Y7NKQZtsTtJIVOfa8b7cbQVmNcXSOzZLwjhM7a3EHdExU2sMP3WRiq2XD9kMLre4g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "underscore": "^1.13.2"
       }
     },
     "node_modules/axe-core": {
@@ -6100,6 +3696,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6263,30 +3860,6 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
       }
     },
     "node_modules/buffer-crc32": {
@@ -6477,12 +4050,6 @@
       ],
       "license": "CC-BY-4.0",
       "peer": true
-    },
-    "node_modules/canonicalize": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-1.0.8.tgz",
-      "integrity": "sha512-0CNTVCLZggSh7bc5VkX5WWPWO+cyZbNd07IHIsSXLia/eAq+r836hgk+8BKoEh7949Mda87VUOitx5OddVj64A==",
-      "license": "Apache-2.0"
     },
     "node_modules/chai": {
       "version": "4.5.0",
@@ -6678,6 +4245,7 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
@@ -6737,23 +4305,11 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/color": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/color/-/color-5.0.3.tgz",
-      "integrity": "sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^3.1.3",
-        "color-string": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -6766,49 +4322,8 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
       "license": "MIT"
-    },
-    "node_modules/color-string": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
-      "integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/color-string/node_modules/color-name": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
-      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.20"
-      }
-    },
-    "node_modules/color/node_modules/color-convert": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.3.tgz",
-      "integrity": "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.6"
-      }
-    },
-    "node_modules/color/node_modules/color-name": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
-      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.20"
-      }
     },
     "node_modules/colorette": {
       "version": "1.4.0",
@@ -6955,39 +4470,6 @@
         "array-ify": "^1.0.0",
         "dot-prop": "^5.1.0"
       }
-    },
-    "node_modules/componentsjs": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/componentsjs/-/componentsjs-4.5.0.tgz",
-      "integrity": "sha512-0F473HDUFfizVXZH1KBP4jmZRBAqYdVdpGhaNmHFmla/AB76B8NN7hQk7YDGaKkESl9zYqQ6kF3i8UgJBQ+rtg==",
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/minimist": "^1.2.0",
-        "@types/node": "^14.14.7",
-        "@types/semver": "^7.3.4",
-        "jsonld-context-parser": "^2.1.1",
-        "minimist": "^1.2.0",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-object": "^1.11.1",
-        "rdf-parse": "^1.9.1",
-        "rdf-quad": "^1.5.0",
-        "rdf-terms": "^1.7.0",
-        "semver": "^7.3.2",
-        "winston": "^3.3.3"
-      },
-      "bin": {
-        "componentsjs-compile-config": "bin/compile-config.js"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
-    "node_modules/componentsjs/node_modules/@types/node": {
-      "version": "14.18.63",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
-      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
-      "license": "MIT"
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -7166,15 +4648,6 @@
         "typescript": ">=4"
       }
     },
-    "node_modules/cross-fetch": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
-      "integrity": "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==",
-      "license": "MIT",
-      "dependencies": {
-        "node-fetch": "^2.7.0"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -7326,12 +4799,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/decimal.js": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
-      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
-      "license": "MIT"
     },
     "node_modules/deep-eql": {
       "version": "4.1.4",
@@ -7591,29 +5058,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/dom-serializer": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
-      "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.2.0",
-        "entities": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-      }
-    },
-    "node_modules/dom-serializer/node_modules/entities": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-      "license": "BSD-2-Clause",
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
     "node_modules/dom5": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dom5/-/dom5-3.0.1.tgz",
@@ -7647,6 +5091,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
       "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7655,40 +5100,11 @@
       ],
       "license": "BSD-2-Clause"
     },
-    "node_modules/domhandler": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
-      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "domelementtype": "^2.2.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
     "node_modules/dompurify": {
       "version": "2.5.8",
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.8.tgz",
       "integrity": "sha512-o1vSNgrmYMQObbSSvF/1brBYEQPHhV1+gsmrusO7/GXtp1T9rCS8cXFqVxK/9crT1jA6Ccv+5MTSjBNqr7Sovw==",
       "license": "(MPL-2.0 OR Apache-2.0)"
-    },
-    "node_modules/domutils": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
-      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "dom-serializer": "^1.0.1",
-        "domelementtype": "^2.2.0",
-        "domhandler": "^4.2.0"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domutils?sponsor=1"
-      }
     },
     "node_modules/dot-prop": {
       "version": "5.3.0",
@@ -7753,12 +5169,6 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/enabled": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
-      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -7829,18 +5239,6 @@
       },
       "engines": {
         "node": ">=8.6"
-      }
-    },
-    "node_modules/entities": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
-      "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/errno": {
@@ -8054,6 +5452,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -8757,18 +6156,11 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/events": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.x"
       }
     },
     "node_modules/execa": {
@@ -8898,6 +6290,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
@@ -8911,7 +6304,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
       "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -8944,12 +6336,6 @@
         "pend": "~1.2.0"
       }
     },
-    "node_modules/fecha": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
-      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
-      "license": "MIT"
-    },
     "node_modules/fetch-cookie": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/fetch-cookie/-/fetch-cookie-0.11.0.tgz",
@@ -8962,31 +6348,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/fetch-sparql-endpoint": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/fetch-sparql-endpoint/-/fetch-sparql-endpoint-2.4.1.tgz",
-      "integrity": "sha512-4tDjPaRM3NH7CZ7ovLpFpyGQMtOH3L6LO/mbGT8ekHKvZyuXIkrykPTDmb0aEM13Wh1X1SzmQC22yqD8ORKe3w==",
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/readable-stream": "^2.3.11",
-        "@types/sparqljs": "^3.1.3",
-        "abort-controller": "^3.0.0",
-        "cross-fetch": "^3.0.6",
-        "is-stream": "^2.0.0",
-        "minimist": "^1.2.0",
-        "n3": "^1.6.3",
-        "rdf-string": "^1.6.0",
-        "readable-web-to-node-stream": "^3.0.2",
-        "sparqljs": "^3.1.2",
-        "sparqljson-parse": "^1.7.0",
-        "sparqlxml-parse": "^1.5.0",
-        "stream-to-string": "^1.1.0"
-      },
-      "bin": {
-        "fetch-sparql-endpoint": "bin/fetch-sparql-endpoint.js"
       }
     },
     "node_modules/file-entry-cache": {
@@ -9120,32 +6481,6 @@
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/fn.name": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
-      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
-      "license": "MIT"
-    },
-    "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
     },
     "node_modules/for-each": {
       "version": "0.3.5",
@@ -9320,6 +6655,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -9638,45 +6974,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/graphql": {
-      "version": "15.10.1",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.10.1.tgz",
-      "integrity": "sha512-BL/Xd/T9baO6NFzoMpiMD7YUZ62R6viR5tp/MULVEnbYJXZA//kRNW7J0j1w/wXArgL0sCxhDfK5dczSKn3+cg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.x"
-      }
-    },
-    "node_modules/graphql-ld": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/graphql-ld/-/graphql-ld-1.4.1.tgz",
-      "integrity": "sha512-oJ8o/1DdAbM+oNE9FBnc0bbWgzvImnl/o2fty2NzA4nyj4T6HNbAkr1CcUL9OieSZPEAW7QcU7W66OVHkxDwVw==",
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "graphql-to-sparql": "^2.4.0",
-        "jsonld-context-parser": "^2.1.0",
-        "sparqlalgebrajs": "^3.0.2",
-        "sparqljson-to-tree": "^2.1.0"
-      }
-    },
-    "node_modules/graphql-to-sparql": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/graphql-to-sparql/-/graphql-to-sparql-2.4.0.tgz",
-      "integrity": "sha512-AwfWSV8NUe5aY2QR+NzUUxImbe8GrUR12PvYBHq6r62aj66667yLdI5xOPsVGcS0DsQJN8+9CXC+vhkjc8mR9Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "graphql": "^15.0.0",
-        "jsonld-context-parser": "^2.0.2",
-        "minimist": "^1.2.0",
-        "rdf-data-factory": "^1.1.0",
-        "sparqlalgebrajs": "^3.0.2"
-      },
-      "bin": {
-        "graphql-to-sparql": "bin/graphql-to-sparql.js"
-      }
-    },
     "node_modules/growl": {
       "version": "1.10.5",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
@@ -9819,22 +7116,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/hash.js": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
-      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "minimalistic-assert": "^1.0.1"
-      }
-    },
-    "node_modules/hash.js/node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC"
-    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -9898,25 +7179,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/htmlparser2": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.2.0.tgz",
-      "integrity": "sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==",
-      "funding": [
-        "https://github.com/fb55/htmlparser2?sponsor=1",
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.2.2",
-        "domutils": "^2.8.0",
-        "entities": "^3.0.1"
-      }
-    },
     "node_modules/http-assert": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/http-assert/-/http-assert-1.5.0.tgz",
@@ -9964,15 +7226,6 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/http-link-header": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/http-link-header/-/http-link-header-1.1.3.tgz",
-      "integrity": "sha512-3cZ0SRL8fb9MUlU3mKM61FcQvPfXx2dBrZW3Vbg5CXa8jFlK8OaEpePenLe1oEXQduhz8b0QjsqfS59QP4AJDQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.0.0"
-      }
     },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
@@ -10031,6 +7284,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -10064,15 +7318,6 @@
       "dev": true,
       "license": "MIT",
       "peer": true
-    },
-    "node_modules/immutable": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
-      "integrity": "sha512-15gZoQ38eYjEjxkorfbcgBKBL6R7T459OuK+CpcWt7O3KF4uPCx2tD0uFETlUDIyo+1789crbMhTvQBSR5yBMg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
@@ -10555,6 +7800,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -10867,6 +8113,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -11159,7 +8406,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stable-stringify": {
@@ -11234,66 +8480,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/jsonld-context-parser": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/jsonld-context-parser/-/jsonld-context-parser-2.4.0.tgz",
-      "integrity": "sha512-ZYOfvh525SdPd9ReYY58dxB3E2RUEU4DJ6ZibO8AitcowPeBH4L5rCAitE2om5G1P+HMEgYEYEr4EZKbVN4tpA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/http-link-header": "^1.0.1",
-        "@types/node": "^18.0.0",
-        "cross-fetch": "^3.0.6",
-        "http-link-header": "^1.0.2",
-        "relative-to-absolute-iri": "^1.0.5"
-      },
-      "bin": {
-        "jsonld-context-parse": "bin/jsonld-context-parse.js"
-      }
-    },
-    "node_modules/jsonld-context-parser/node_modules/@types/node": {
-      "version": "18.19.130",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
-      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
-    },
-    "node_modules/jsonld-context-parser/node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "license": "MIT"
-    },
-    "node_modules/jsonld-streaming-parser": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/jsonld-streaming-parser/-/jsonld-streaming-parser-2.4.3.tgz",
-      "integrity": "sha512-ysuevJ+l8+Y4W3J/yQW3pa9VCBNDHo2tZkKmPAnfhfsmFMyxuueAeXMmTbpJZdrpagzeeDVr3A8EZVuHliQJ9A==",
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/http-link-header": "^1.0.1",
-        "canonicalize": "^1.0.1",
-        "http-link-header": "^1.0.2",
-        "jsonld-context-parser": "^2.1.3",
-        "jsonparse": "^1.3.1",
-        "rdf-data-factory": "^1.1.0"
-      }
-    },
-    "node_modules/jsonld-streaming-serializer": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/jsonld-streaming-serializer/-/jsonld-streaming-serializer-1.3.0.tgz",
-      "integrity": "sha512-QGflpxpwmr659ExvAQ5TFAY9BmJQiL/yF/MDRrP5oVWHcBBLhbPjUqDv//y2OvJxUY3UQYMXulTwzmYb1ttv2Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "jsonld-context-parser": "^2.0.0"
-      }
-    },
     "node_modules/jsonparse": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
       "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
+      "dev": true,
       "engines": [
         "node >= 0.2.0"
       ],
@@ -11303,6 +8494,7 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
       "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+      "dev": true,
       "license": "(MIT OR Apache-2.0)",
       "dependencies": {
         "jsonparse": "^1.2.0",
@@ -11495,12 +8687,6 @@
       "dependencies": {
         "ms": "^2.1.1"
       }
-    },
-    "node_modules/kuler": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
-      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
-      "license": "MIT"
     },
     "node_modules/language-subtag-registry": {
       "version": "0.3.23",
@@ -12211,23 +9397,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/logform": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz",
-      "integrity": "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@colors/colors": "1.6.0",
-        "@types/triple-beam": "^1.3.2",
-        "fecha": "^4.2.0",
-        "ms": "^2.1.1",
-        "safe-stable-stringify": "^2.3.1",
-        "triple-beam": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
     "node_modules/loupe": {
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
@@ -12416,46 +9585,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/microdata-rdf-streaming-parser": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/microdata-rdf-streaming-parser/-/microdata-rdf-streaming-parser-1.2.0.tgz",
-      "integrity": "sha512-cMLNLEcS0mPaiA9iwq6BnsQK9sx2uBwjpRZIEvMRBNJpbvV58f8AFtPeYzNFh3OPyX9B49NYJ77bB0jNAUCurw==",
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "htmlparser2": "^6.0.0",
-        "rdf-data-factory": "^1.1.0",
-        "relative-to-absolute-iri": "^1.0.2"
-      }
-    },
-    "node_modules/microdata-rdf-streaming-parser/node_modules/entities": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-      "license": "BSD-2-Clause",
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/microdata-rdf-streaming-parser/node_modules/htmlparser2": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
-      "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
-      "funding": [
-        "https://github.com/fb55/htmlparser2?sponsor=1",
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.0.0",
-        "domutils": "^2.5.2",
-        "entities": "^2.0.0"
-      }
-    },
     "node_modules/micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -12513,12 +9642,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/minimalistic-assert": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
-      "license": "ISC"
-    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -12536,6 +9659,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -13016,20 +10140,8 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
       "license": "MIT"
-    },
-    "node_modules/n3": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/n3/-/n3-1.26.0.tgz",
-      "integrity": "sha512-SQknS0ua90rN+3RHuk8BeIqeYyqIH/+ecViZxX08jR4j6MugqWRjtONl3uANG/crWXnOM2WIqBJtjIhVYFha+w==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^6.0.3",
-        "readable-stream": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=12.0"
-      }
     },
     "node_modules/nan-x": {
       "version": "1.0.2",
@@ -13082,11 +10194,6 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/negotiate": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/negotiate/-/negotiate-1.0.1.tgz",
-      "integrity": "sha512-KBCIM4dAIT9j/pSXLHHQbZG74NmKNXTtxU2zHN0HG6uzzuFE01m1UdGoUmVHmACiBuCAOL7KwfqSW1oUQBj/vg=="
     },
     "node_modules/negotiator": {
       "version": "0.6.3",
@@ -13161,48 +10268,6 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/node-fetch/node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
-    },
-    "node_modules/node-fetch/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/node-fetch/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/node-gyp-build": {
@@ -13484,15 +10549,6 @@
         "wrappy": "1"
       }
     },
-    "node_modules/one-time": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
-      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
-      "license": "MIT",
-      "dependencies": {
-        "fn.name": "1.x.x"
-      }
-    },
     "node_modules/onetime": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
@@ -13720,15 +10776,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/parse-link-header": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parse-link-header/-/parse-link-header-1.0.1.tgz",
-      "integrity": "sha512-Z0gpfHmwCIKDr5rRzjypL+p93aHVWO7e+0rFcUl9E3sC67njjs+xHFenuboSXZGlvYtmQqRzRaE3iFpTUnLmFQ==",
-      "license": "MIT",
-      "dependencies": {
-        "xtend": "~4.0.1"
       }
     },
     "node_modules/parse5": {
@@ -14416,15 +11463,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/process": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
     "node_modules/progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -14434,12 +11472,6 @@
       "engines": {
         "node": ">=0.4.0"
       }
-    },
-    "node_modules/promise-polyfill": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-1.1.6.tgz",
-      "integrity": "sha512-7rrONfyLkDEc7OJ5QBkqa4KI4EBhCd340xRuIUPGCfu13znS+vx+VDdrT9ODAJHlXm7w4lbxN3DRjyv58EuzDg==",
-      "license": "MIT"
     },
     "node_modules/property-is-enumerable-x": {
       "version": "1.1.0",
@@ -14500,6 +11532,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -14771,190 +11804,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/rdf-data-factory": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.3.tgz",
-      "integrity": "sha512-ny6CI7m2bq4lfQQmDYvcb2l1F9KtGwz9chipX4oWu2aAtVoXjb7k3d8J1EsgAsEbMXnBipB/iuRen5H2fwRWWQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "^1.0.0"
-      }
-    },
-    "node_modules/rdf-data-factory/node_modules/@rdfjs/types": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.2.tgz",
-      "integrity": "sha512-wqpOJK1QCbmsGNtyzYnojPU8gRDPid2JO0Q0kMtb4j65xhCK880cnKAfEOwC+dX85VJcCByQx5zOwyyfCjDJsg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/rdf-isomorphic": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/rdf-isomorphic/-/rdf-isomorphic-1.3.1.tgz",
-      "integrity": "sha512-6uIhsXTVp2AtO6f41PdnRV5xZsa0zVZQDTBdn0br+DZuFf5M/YD+T6m8hKDUnALI6nFL/IujTMLgEs20MlNidQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "hash.js": "^1.1.7",
-        "rdf-string": "^1.6.0",
-        "rdf-terms": "^1.7.0"
-      }
-    },
-    "node_modules/rdf-literal": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/rdf-literal/-/rdf-literal-1.3.2.tgz",
-      "integrity": "sha512-79Stlu3sXy0kq9/decHFLf3xNPuY6sfhFPhd/diWErgaFr0Ekyg38Vh9bnVcqDYu48CFRi0t+hrFii49n92Hbw==",
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "rdf-data-factory": "^1.1.0"
-      }
-    },
-    "node_modules/rdf-object": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/rdf-object/-/rdf-object-1.14.0.tgz",
-      "integrity": "sha512-/KSUWr7onDtL7d81kOpcUzJ2vHYOYJc2KU9WzBZRYydBhK0Sksh5Hg4VCQNaxUEvYEgdrrTuq9SLpOOCmag0rQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "jsonld-context-parser": "^2.0.2",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-string": "^1.6.0",
-        "streamify-array": "^1.0.1"
-      }
-    },
-    "node_modules/rdf-parse": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/rdf-parse/-/rdf-parse-1.9.1.tgz",
-      "integrity": "sha512-W6ouYE+ufmCNFmXD1iGs5gUZH75jZekh/I5qF8a4Sl37BUc9mY0Jz5A0CV1tiKKhx+I+HYfxyX9VjOljD8rzgQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/actor-http-native": "~1.22.0",
-        "@comunica/actor-rdf-parse-html": "~1.22.0",
-        "@comunica/actor-rdf-parse-html-microdata": "~1.22.0",
-        "@comunica/actor-rdf-parse-html-rdfa": "~1.22.0",
-        "@comunica/actor-rdf-parse-html-script": "~1.22.0",
-        "@comunica/actor-rdf-parse-jsonld": "^1.22.0",
-        "@comunica/actor-rdf-parse-n3": "~1.22.0",
-        "@comunica/actor-rdf-parse-rdfxml": "~1.22.0",
-        "@comunica/actor-rdf-parse-xml-rdfa": "~1.22.0",
-        "@comunica/bus-http": "~1.22.0",
-        "@comunica/bus-init": "~1.22.0",
-        "@comunica/bus-rdf-parse": "~1.22.0",
-        "@comunica/bus-rdf-parse-html": "~1.22.0",
-        "@comunica/core": "~1.22.0",
-        "@comunica/mediator-combine-union": "~1.22.0",
-        "@comunica/mediator-number": "~1.22.0",
-        "@comunica/mediator-race": "~1.22.0",
-        "@rdfjs/types": "*",
-        "stream-to-string": "^1.2.0"
-      }
-    },
-    "node_modules/rdf-quad": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/rdf-quad/-/rdf-quad-1.5.0.tgz",
-      "integrity": "sha512-LnCYx8XbRVW1wr6UiZPSy2Tv7bXAtEwuyck/68dANhFu8VMnGS+QfUNP3b9YI6p4Bfd/fyDx5E3x81IxGV6BzA==",
-      "license": "MIT",
-      "dependencies": {
-        "rdf-data-factory": "^1.0.1",
-        "rdf-literal": "^1.2.0",
-        "rdf-string": "^1.5.0"
-      }
-    },
-    "node_modules/rdf-store-stream": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/rdf-store-stream/-/rdf-store-stream-1.3.1.tgz",
-      "integrity": "sha512-+cpnGKJMwFbCa/L0fogSMrNA95P+T2tSoWWXj94IdGN2UdYu+oQpaP7vav5wGenWQ1J9/nQu6Sy0m+stNfAZFw==",
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "n3": "^1.11.1"
-      }
-    },
-    "node_modules/rdf-string": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-1.6.3.tgz",
-      "integrity": "sha512-HIVwQ2gOqf+ObsCLSUAGFZMIl3rh9uGcRf1KbM85UDhKqP+hy6qj7Vz8FKt3GA54RiThqK3mNcr66dm1LP0+6g==",
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "rdf-data-factory": "^1.1.0"
-      }
-    },
-    "node_modules/rdf-string-ttl": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/rdf-string-ttl/-/rdf-string-ttl-1.3.2.tgz",
-      "integrity": "sha512-yqolaVoUvTaSC5aaQuMcB4BL54G/pCGsV4jQH87f0TvAx8zHZG0koh7XWrjva/IPGcVb1QTtaeEdfda5mcddJg==",
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "rdf-data-factory": "^1.1.0"
-      }
-    },
-    "node_modules/rdf-terms": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/rdf-terms/-/rdf-terms-1.11.0.tgz",
-      "integrity": "sha512-iKlVgnMopRKl9pHVNrQrax7PtZKRCT/uJIgYqvuw1VVQb88zDvurtDr1xp0rt7N9JtKtFwUXoIQoEsjyRo20qQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-string": "^1.6.0"
-      }
-    },
-    "node_modules/rdfa-streaming-parser": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/rdfa-streaming-parser/-/rdfa-streaming-parser-1.5.0.tgz",
-      "integrity": "sha512-A+Kl0vbRQKK3SqgWdCiR48Hi75LK6z6glPdGcbLXMw6qMRcLeIKe4p6yFkPXpbwtegmOa94uaxeLs5HMdo66AQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "htmlparser2": "^6.0.0",
-        "rdf-data-factory": "^1.1.0",
-        "relative-to-absolute-iri": "^1.0.2"
-      }
-    },
-    "node_modules/rdfa-streaming-parser/node_modules/entities": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-      "license": "BSD-2-Clause",
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/rdfa-streaming-parser/node_modules/htmlparser2": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
-      "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
-      "funding": [
-        "https://github.com/fb55/htmlparser2?sponsor=1",
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.0.0",
-        "domutils": "^2.5.2",
-        "entities": "^2.0.0"
-      }
-    },
-    "node_modules/rdfxml-streaming-parser": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/rdfxml-streaming-parser/-/rdfxml-streaming-parser-1.5.0.tgz",
-      "integrity": "sha512-pnt+7NgeqCMd2/rub+dqxzYJhZwJjBNU2BRwyYdCTmRZu2fr795jCPJB6Io5pjPzAt29ASqy+ODBSRMDKoKGbQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "rdf-data-factory": "^1.1.0",
-        "relative-to-absolute-iri": "^1.0.0",
-        "sax": "^1.2.4"
-      }
-    },
     "node_modules/read-pkg": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
@@ -15095,44 +11944,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/readable-stream": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
-      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
-      "license": "MIT",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/readable-stream-node-to-web": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/readable-stream-node-to-web/-/readable-stream-node-to-web-1.0.1.tgz",
-      "integrity": "sha512-OGzi2VKLa8H259kAx7BIwuRrXHGcxeHj4RdASSgEGBP9Q2wowdPvBc65upF4Q9O05qWgKqBw1+9PiLTtObl7uQ==",
-      "license": "MIT"
-    },
-    "node_modules/readable-web-to-node-stream": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.4.tgz",
-      "integrity": "sha512-9nX56alTf5bwXQ3ZDipHJhusu9NTQJ/CVPtb/XHAJCXihZeitfJvIRS4GqQ/mfIoOE3IelHMrpayVrosdHBuLw==",
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "^4.7.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
-      }
-    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -15257,12 +12068,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/relative-to-absolute-iri": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/relative-to-absolute-iri/-/relative-to-absolute-iri-1.0.7.tgz",
-      "integrity": "sha512-Xjyl4HmIzg2jzK/Un2gELqbcE8Fxy85A/aLSHE6PE/3+OGsFwmKVA1vRyGaz6vLWSqLDMHA+5rjD/xbibSQN1Q==",
-      "license": "MIT"
-    },
     "node_modules/replace-comments-x": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/replace-comments-x/-/replace-comments-x-2.0.0.tgz",
@@ -15297,6 +12102,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -15306,7 +12112,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -15634,12 +12439,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "license": "MIT"
-    },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
@@ -15675,54 +12474,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/safe-stable-stringify": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
-      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/sax": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.4.tgz",
-      "integrity": "sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=11.0.0"
-      }
-    },
-    "node_modules/sax-stream": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/sax-stream/-/sax-stream-1.3.0.tgz",
-      "integrity": "sha512-tcfsAAICAkyNNe4uiKtKmLKxx3C7qPAej13UUoN+7OLYq/P5kHGahZtJhhMVM3fIMndA6TlYHWFlFEzFkv1VGg==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "~2",
-        "sax": "~1"
-      }
-    },
-    "node_modules/sax-stream/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/sax-stream/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
     "node_modules/scope-eval": {
@@ -15737,6 +12493,7 @@
       "version": "7.6.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
       "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -15759,6 +12516,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
@@ -15771,6 +12529,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/set-blocking": {
@@ -16016,116 +12775,6 @@
       "license": "WTFPL",
       "peer": true
     },
-    "node_modules/sparqlalgebrajs": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.3.tgz",
-      "integrity": "sha512-XFNhsO55bprayrM35h/jY0kzzuGc3oZ1On3kc+s7Un0BFQBXa046aLcMZFp4MYSvn7GtMe9eZ08ONFnBH5kEsQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.2",
-        "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.5",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.4.2"
-      },
-      "bin": {
-        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
-      }
-    },
-    "node_modules/sparqlee": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/sparqlee/-/sparqlee-1.10.0.tgz",
-      "integrity": "sha512-rKuyXIIyEsRsACZC86yrN0m/rUhKZQl6HfqeIqAC+5WXE08PB/tGQ9RPxiwo+P6u6QEk2Sd/h6Yq1pnT0607JA==",
-      "deprecated": "Sparqlee has been moved to @comunica/expression-evaluator",
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/spark-md5": "^3.0.2",
-        "@types/uuid": "^8.0.0",
-        "decimal.js": "^10.2.0",
-        "hash.js": "^1.1.7",
-        "immutable": "^3.8.2",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-string": "^1.6.0",
-        "relative-to-absolute-iri": "^1.0.6",
-        "spark-md5": "^3.0.1",
-        "sparqlalgebrajs": "^3.0.2",
-        "uuid": "^8.0.0"
-      },
-      "bin": {
-        "sparqlee": "dist/bin/Sparqlee.js"
-      }
-    },
-    "node_modules/sparqlee/node_modules/spark-md5": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/spark-md5/-/spark-md5-3.0.2.tgz",
-      "integrity": "sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw==",
-      "license": "(WTFPL OR MIT)"
-    },
-    "node_modules/sparqljs": {
-      "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.7.3.tgz",
-      "integrity": "sha512-FQfHUhfwn5PD9WH6xPU7DhFfXMgqK/XoDrYDVxz/grhw66Il0OjRg3JBgwuEvwHnQt7oSTiKWEiCZCPNaUbqgg==",
-      "license": "MIT",
-      "dependencies": {
-        "rdf-data-factory": "^1.1.2"
-      },
-      "bin": {
-        "sparqljs": "bin/sparql-to-json"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/sparqljson-parse": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/sparqljson-parse/-/sparqljson-parse-1.7.0.tgz",
-      "integrity": "sha512-/88g7aK1QZ42YvMx+nStNeZsiVJhmg/OC4RNnQk+ybItvEkQiTOpnYDmST5FnzOIsSmp5RxAZDCIDdMK1h7Ynw==",
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/node": "^13.1.0",
-        "JSONStream": "^1.3.3",
-        "rdf-data-factory": "^1.1.0"
-      }
-    },
-    "node_modules/sparqljson-parse/node_modules/@types/node": {
-      "version": "13.13.52",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.52.tgz",
-      "integrity": "sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ==",
-      "license": "MIT"
-    },
-    "node_modules/sparqljson-to-tree": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/sparqljson-to-tree/-/sparqljson-to-tree-2.1.0.tgz",
-      "integrity": "sha512-LwEMlrvjzEigatJ8iw1RKGWL9dKmATQNbTEXyadzsOQxbBhJNaGk8G9/WPCcVj2zlCPKGMysfNGb4UfvwHKeSw==",
-      "license": "MIT",
-      "dependencies": {
-        "rdf-literal": "^1.2.0",
-        "sparqljson-parse": "^1.6.0"
-      }
-    },
-    "node_modules/sparqlxml-parse": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/sparqlxml-parse/-/sparqlxml-parse-1.5.0.tgz",
-      "integrity": "sha512-+0DCekgO3G6ugeVntrZS6+Fj60MsHR0q51WoRAdVzARb5V3jhX3dZJbwSaeydsOsXrtts4XSMc/z+kbqy5/VUQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/node": "^13.1.0",
-        "rdf-data-factory": "^1.1.0",
-        "sax-stream": "^1.2.3"
-      }
-    },
-    "node_modules/sparqlxml-parse/node_modules/@types/node": {
-      "version": "13.13.52",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.52.tgz",
-      "integrity": "sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ==",
-      "license": "MIT"
-    },
     "node_modules/spdx-correct": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
@@ -16179,15 +12828,6 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
-    "node_modules/stack-trace": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
-      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/statuses": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
@@ -16212,31 +12852,11 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/stream-to-string": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/stream-to-string/-/stream-to-string-1.2.1.tgz",
-      "integrity": "sha512-WsvTDNF8UYs369Yko3pcdTducQtYpzEZeOV7cTuReyFvOoA9S/DLJ6sYK+xPafSPHhUMpaxiljKYnT6JSFztIA==",
-      "license": "MIT",
-      "dependencies": {
-        "promise-polyfill": "^1.1.6"
-      }
-    },
-    "node_modules/streamify-array": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/streamify-array/-/streamify-array-1.0.1.tgz",
-      "integrity": "sha512-ZnswaBcC6B1bhPLSQOlC6CdaDUSzU0wr2lvvHpbHNms8V7+DLd8uEAzDAWpsjxbFkijBHhuObFO/qqu52DZUMA==",
-      "license": "MIT"
-    },
-    "node_modules/streamify-string": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/streamify-string/-/streamify-string-1.0.1.tgz",
-      "integrity": "sha512-RXvBglotrvSIuQQ7oC55pdV40wZ/17gTb68ipMC4LA0SqMN4Sqfsf31Dpei7qXpYqZQ8ueVnPglUvtep3tlhqw==",
-      "license": "MIT"
-    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -16246,6 +12866,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -16276,6 +12897,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -16313,6 +12935,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/string.prototype.trim": {
@@ -16403,6 +13026,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -16586,12 +13210,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/text-hex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
-      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
-      "license": "MIT"
-    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -16603,6 +13221,7 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/through2": {
@@ -16636,12 +13255,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/tiny-set-immediate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/tiny-set-immediate/-/tiny-set-immediate-1.0.2.tgz",
-      "integrity": "sha512-EVbaM4zXFWS4CIqVoPzY7XIioQ5LU1p49AHizwPO1KyFyp/gxy5SA8mDmfDVl/2WLQiHgUL+esO6Ig+KhpUxUw==",
-      "license": "MIT"
     },
     "node_modules/to-boolean-x": {
       "version": "1.0.3",
@@ -16917,15 +13530,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/triple-beam": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
-      "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14.0.0"
       }
     },
     "node_modules/tsconfig-paths": {
@@ -17212,10 +13816,17 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/underscore": {
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
+      "license": "MIT"
+    },
     "node_modules/undici-types": {
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/uniq": {
@@ -17389,15 +14000,11 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
       }
-    },
-    "node_modules/uritemplate": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/uritemplate/-/uritemplate-0.3.4.tgz",
-      "integrity": "sha512-enADBvHfhjrwxFMTVWeIIYz51SZ91uC6o2MR/NQTVljJB6HTZ8eQL3Q7JBj3RxNISA14MOwJaU3vpf5R6dyxHA=="
     },
     "node_modules/url-parse": {
       "version": "1.5.10",
@@ -17415,13 +14022,16 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -17540,32 +14150,6 @@
       "dev": true,
       "license": "Apache-2.0",
       "peer": true
-    },
-    "node_modules/web-streams-node": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/web-streams-node/-/web-streams-node-0.4.0.tgz",
-      "integrity": "sha512-u+PBQs8DFaBrN/bxCLFn21tO/ZP7EM3qA4FGzppoUCcZ5CaMbKOsN8uOp27ylVEsfrxcR2tsF6gWHI5M8bN73w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "is-stream": "^1.1.0",
-        "readable-stream-node-to-web": "^1.0.1",
-        "web-streams-ponyfill": "^1.4.1"
-      }
-    },
-    "node_modules/web-streams-node/node_modules/is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/web-streams-ponyfill": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/web-streams-ponyfill/-/web-streams-ponyfill-1.4.2.tgz",
-      "integrity": "sha512-LCHW+fE2UBJ2vjhqJujqmoxh1ytEDEr0dPO3CabMdMDJPKmsaxzS90V1Ar6LtNE5VHLqxR4YMEj1i4lzMAccIA==",
-      "license": "MIT"
     },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
@@ -17771,82 +14355,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/winston": {
-      "version": "3.19.0",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-3.19.0.tgz",
-      "integrity": "sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==",
-      "license": "MIT",
-      "dependencies": {
-        "@colors/colors": "^1.6.0",
-        "@dabh/diagnostics": "^2.0.8",
-        "async": "^3.2.3",
-        "is-stream": "^2.0.0",
-        "logform": "^2.7.0",
-        "one-time": "^1.0.0",
-        "readable-stream": "^3.4.0",
-        "safe-stable-stringify": "^2.3.1",
-        "stack-trace": "0.0.x",
-        "triple-beam": "^1.3.0",
-        "winston-transport": "^4.9.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/winston-transport": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.9.0.tgz",
-      "integrity": "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==",
-      "license": "MIT",
-      "dependencies": {
-        "logform": "^2.7.0",
-        "readable-stream": "^3.6.2",
-        "triple-beam": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/winston-transport/node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC"
-    },
-    "node_modules/winston-transport/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/winston/node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC"
-    },
-    "node_modules/winston/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -17871,6 +14379,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -17950,17 +14459,13 @@
         }
       }
     },
-    "node_modules/xml": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
-      "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
-      "license": "MIT"
-    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.4"
       }
@@ -17969,6 +14474,7 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -17996,6 +14502,7 @@
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
@@ -18254,6 +14761,7 @@
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-summary",
   "description": "A summary view for an API base on AMF data model",
-  "version": "4.6.19",
+  "version": "4.6.20",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",
@@ -30,7 +30,7 @@
     "@advanced-rest-client/markdown-styles": "^3.1.5",
     "@api-components/amf-helper-mixin": "^4.5.36",
     "@api-components/api-method-documentation": "^5.2.5",
-    "@api-components/api-model-generator": "^0.2.14",
+    "@api-components/api-model-generator": "^0.4.0",
     "@api-components/http-method-label": "^3.1.4",
     "@api-components/raml-aware": "^3.0.0",
     "dompurify": "^2.3.3",

--- a/src/Styles.js
+++ b/src/Styles.js
@@ -144,6 +144,24 @@ export default css`
     color: var(--http-method-label-query-color, #0f9d9d);
   }
 
+  .method-label[data-method='copy'],
+  .method-label[data-method='COPY'] {
+    background-color: var(
+      --http-method-label-copy-background-color,
+      rgba(92, 107, 192, 0.12)
+    );
+    color: var(--http-method-label-copy-color, #5c6bc0);
+  }
+
+  .method-label[data-method='move'],
+  .method-label[data-method='MOVE'] {
+    background-color: var(
+      --http-method-label-move-background-color,
+      rgba(184, 134, 11, 0.12)
+    );
+    color: var(--http-method-label-move-color, #b8860b);
+  }
+
   .grpc-stream-type {
     display: inline-block;
     min-width: auto;

--- a/src/Styles.js
+++ b/src/Styles.js
@@ -135,6 +135,15 @@ export default css`
     gap: 8px;
   }
 
+  .method-label[data-method='query'],
+  .method-label[data-method='QUERY'] {
+    background-color: var(
+      --http-method-label-query-background-color,
+      rgba(15, 157, 157, 0.12)
+    );
+    color: var(--http-method-label-query-color, #0f9d9d);
+  }
+
   .grpc-stream-type {
     display: inline-block;
     min-width: auto;

--- a/test/amf-loader.js
+++ b/test/amf-loader.js
@@ -1,3 +1,33 @@
+import { AmfHelperMixin } from '@api-components/amf-helper-mixin/amf-helper-mixin.js';
+
+/**
+ * amf-client-js 5.11.x emits models in flattened `@graph` form
+ * (`{"@graph":[...]}`), whereas 4.7 emitted a plain array (`[{...}]`).
+ * Tests that navigate the loaded model directly break on the raw `@graph`
+ * form (`_computeApi` returns `undefined`).
+ *
+ * The component's `amf` setter already expands internally (via
+ * `AmfHelperMixin._expand`), so runtime is fine — but we expand here, at load
+ * time, so every consumer receives a navigable (expanded) model. Re-feeding an
+ * already-expanded model to the setter is idempotent (the expander is a no-op
+ * when there is no `@graph`, e.g. the committed 4.7 gRPC fixture).
+ */
+class HelperElement extends AmfHelperMixin(Object) {}
+
+const helper = new HelperElement();
+
+/**
+ * Expands a raw (possibly flattened `@graph`) AMF model via the mixin setter
+ * and returns the navigable document node.
+ * @param {any} model Raw API model.
+ * @return {any} Expanded model.
+ */
+const expand = (model) => {
+  helper.amf = model;
+  const { amf } = helper;
+  return Array.isArray(amf) ? amf[0] : amf;
+};
+
 export const AmfLoader = {};
 AmfLoader.load = async function(compact, file='demo-api') {
   file = `/${file}${compact ? '-compact' : ''}.json`;
@@ -12,7 +42,7 @@ AmfLoader.load = async function(compact, file='demo-api') {
         reject(e);
         return;
       }
-      resolve(data);
+      resolve(expand(data));
     });
     xhr.addEventListener('error', () => reject(new Error('Unable to load model file')));
     xhr.open('GET', url);

--- a/test/api-summary.test.js
+++ b/test/api-summary.test.js
@@ -833,4 +833,68 @@ describe('ApiSummary', () => {
       });
     });
   });
+
+  describe('QUERY method (OAS 3.2)', () => {
+    // OAS 3.2 adds the QUERY HTTP method. The summary renders `data-method`
+    // straight from the raw AMF value ("QUERY", upper case) for HTTP operations,
+    // so the color override keys on both casings. This inline expanded model
+    // (no `@context`) keeps the test independent of the model generator.
+    const DOC = 'http://a.ml/vocabularies/document#Document';
+    const ENCODES = 'http://a.ml/vocabularies/document#encodes';
+    const WEBAPI = 'http://a.ml/vocabularies/apiContract#WebAPI';
+    const ENDPOINT = 'http://a.ml/vocabularies/apiContract#endpoint';
+    const ENDPOINT_T = 'http://a.ml/vocabularies/apiContract#EndPoint';
+    const OPERATION_T = 'http://a.ml/vocabularies/apiContract#Operation';
+    const SUPPORTED_OP = 'http://a.ml/vocabularies/apiContract#supportedOperation';
+    const PATH = 'http://a.ml/vocabularies/apiContract#path';
+    const METHOD = 'http://a.ml/vocabularies/apiContract#method';
+
+    function buildQueryModel() {
+      return {
+        '@type': [DOC],
+        [ENCODES]: [{
+          '@id': 'amf://id#1',
+          '@type': [WEBAPI],
+          [ENDPOINT]: [{
+            '@id': 'amf://id#10',
+            '@type': [ENDPOINT_T],
+            [PATH]: [{ '@value': '/pets' }],
+            [SUPPORTED_OP]: [{
+              '@id': 'amf://id#11',
+              '@type': [OPERATION_T],
+              [METHOD]: [{ '@value': 'get' }],
+            }, {
+              '@id': 'amf://id#12',
+              '@type': [OPERATION_T],
+              [METHOD]: [{ '@value': 'QUERY' }],
+            }],
+          }],
+        }],
+      };
+    }
+
+    let element;
+
+    beforeEach(async () => {
+      element = await basicFixture();
+      element.amf = buildQueryModel();
+      // `__amfChanged` defers processing through a setTimeout debouncer.
+      await aTimeout(0);
+      await nextFrame();
+    });
+
+    it('renders a QUERY method-label with data-method="QUERY"', () => {
+      const methods = Array.from(
+        element.shadowRoot.querySelectorAll('.method-label')
+      ).map((node) => node.getAttribute('data-method'));
+      assert.include(methods, 'QUERY', 'a method-label carries the raw QUERY value');
+    });
+
+    it('keeps the raw AMF casing (does not lower-case QUERY)', () => {
+      const methods = Array.from(
+        element.shadowRoot.querySelectorAll('.method-label')
+      ).map((node) => node.getAttribute('data-method'));
+      assert.notInclude(methods, 'query', 'QUERY is not silently lower-cased');
+    });
+  });
 });

--- a/test/api-summary.test.js
+++ b/test/api-summary.test.js
@@ -834,11 +834,12 @@ describe('ApiSummary', () => {
     });
   });
 
-  describe('QUERY method (OAS 3.2)', () => {
-    // OAS 3.2 adds the QUERY HTTP method. The summary renders `data-method`
-    // straight from the raw AMF value ("QUERY", upper case) for HTTP operations,
-    // so the color override keys on both casings. This inline expanded model
-    // (no `@context`) keeps the test independent of the model generator.
+  describe('OAS 3.2 methods (QUERY, COPY, MOVE)', () => {
+    // OAS 3.2 adds the QUERY, COPY and MOVE HTTP methods. The summary renders
+    // `data-method` straight from the raw AMF value ("QUERY", upper case) for
+    // HTTP operations, so the color override keys on both casings. This inline
+    // expanded model (no `@context`) keeps the test independent of the model
+    // generator.
     const DOC = 'http://a.ml/vocabularies/document#Document';
     const ENCODES = 'http://a.ml/vocabularies/document#encodes';
     const WEBAPI = 'http://a.ml/vocabularies/apiContract#WebAPI';
@@ -867,6 +868,14 @@ describe('ApiSummary', () => {
               '@id': 'amf://id#12',
               '@type': [OPERATION_T],
               [METHOD]: [{ '@value': 'QUERY' }],
+            }, {
+              '@id': 'amf://id#13',
+              '@type': [OPERATION_T],
+              [METHOD]: [{ '@value': 'COPY' }],
+            }, {
+              '@id': 'amf://id#14',
+              '@type': [OPERATION_T],
+              [METHOD]: [{ '@value': 'MOVE' }],
             }],
           }],
         }],
@@ -895,6 +904,14 @@ describe('ApiSummary', () => {
         element.shadowRoot.querySelectorAll('.method-label')
       ).map((node) => node.getAttribute('data-method'));
       assert.notInclude(methods, 'query', 'QUERY is not silently lower-cased');
+    });
+
+    it('renders COPY and MOVE method-labels with their raw data-method', () => {
+      const methods = Array.from(
+        element.shadowRoot.querySelectorAll('.method-label')
+      ).map((node) => node.getAttribute('data-method'));
+      assert.include(methods, 'COPY', 'a method-label carries the raw COPY value');
+      assert.include(methods, 'MOVE', 'a method-label carries the raw MOVE value');
     });
   });
 });

--- a/test/api-summary.test.js
+++ b/test/api-summary.test.js
@@ -836,82 +836,103 @@ describe('ApiSummary', () => {
 
   describe('OAS 3.2 methods (QUERY, COPY, MOVE)', () => {
     // OAS 3.2 adds the QUERY, COPY and MOVE HTTP methods. The summary renders
-    // `data-method` straight from the raw AMF value ("QUERY", upper case) for
-    // HTTP operations, so the color override keys on both casings. This inline
-    // expanded model (no `@context`) keeps the test independent of the model
-    // generator.
-    const DOC = 'http://a.ml/vocabularies/document#Document';
-    const ENCODES = 'http://a.ml/vocabularies/document#encodes';
-    const WEBAPI = 'http://a.ml/vocabularies/apiContract#WebAPI';
-    const ENDPOINT = 'http://a.ml/vocabularies/apiContract#endpoint';
-    const ENDPOINT_T = 'http://a.ml/vocabularies/apiContract#EndPoint';
-    const OPERATION_T = 'http://a.ml/vocabularies/apiContract#Operation';
-    const SUPPORTED_OP = 'http://a.ml/vocabularies/apiContract#supportedOperation';
-    const PATH = 'http://a.ml/vocabularies/apiContract#path';
-    const METHOD = 'http://a.ml/vocabularies/apiContract#method';
+    // `data-method` straight from the raw AMF value for HTTP operations, so the
+    // color override in Styles.js keys on both casings (e.g. QUERY teal #0F9D9D
+    // matches both `[data-method='QUERY']` and `[data-method='query']`; COPY
+    // indigo #5c6bc0; MOVE amber #b8860b).
 
-    function buildQueryModel() {
-      return {
-        '@type': [DOC],
-        [ENCODES]: [{
-          '@id': 'amf://id#1',
-          '@type': [WEBAPI],
-          [ENDPOINT]: [{
-            '@id': 'amf://id#10',
-            '@type': [ENDPOINT_T],
-            [PATH]: [{ '@value': '/pets' }],
-            [SUPPORTED_OP]: [{
-              '@id': 'amf://id#11',
-              '@type': [OPERATION_T],
-              [METHOD]: [{ '@value': 'get' }],
-            }, {
-              '@id': 'amf://id#12',
-              '@type': [OPERATION_T],
-              [METHOD]: [{ '@value': 'QUERY' }],
-            }, {
-              '@id': 'amf://id#13',
-              '@type': [OPERATION_T],
-              [METHOD]: [{ '@value': 'COPY' }],
-            }, {
-              '@id': 'amf://id#14',
-              '@type': [OPERATION_T],
-              [METHOD]: [{ '@value': 'MOVE' }],
+    describe('QUERY (from a real generated OAS 3.2 model)', () => {
+      // amf-client-js 5.11 PARSES `query:` from an OAS 3.2 pathItem and emits
+      // its method as "QUERY" (upper case), so the QUERY label is driven from a
+      // real generated model — demo/oas32-query/oas32-query.yaml.
+      let amf;
+      let element = /** @type ApiSummary */ (null);
+
+      before(async () => {
+        amf = await AmfLoader.load(false, 'oas32-query');
+      });
+
+      beforeEach(async () => {
+        element = await basicFixture();
+        element.amf = amf;
+        // `__amfChanged` defers processing through a setTimeout debouncer.
+        await aTimeout(0);
+        await nextFrame();
+      });
+
+      it('renders a QUERY method-label with data-method="QUERY"', () => {
+        const methods = Array.from(
+          element.shadowRoot.querySelectorAll('.method-label')
+        ).map((node) => node.getAttribute('data-method'));
+        assert.include(methods, 'QUERY', 'a method-label carries the raw QUERY value');
+      });
+
+      it('keeps the raw AMF casing (does not lower-case QUERY)', () => {
+        const methods = Array.from(
+          element.shadowRoot.querySelectorAll('.method-label')
+        ).map((node) => node.getAttribute('data-method'));
+        assert.notInclude(methods, 'query', 'QUERY is not silently lower-cased');
+      });
+    });
+
+    describe('COPY / MOVE (inline AMF fragment — not generatable)', () => {
+      // amf-client-js 5.11 REJECTS `copy:`/`move:` in an OAS 3.2 pathItem
+      // ("Property 'copy'/'move' not supported in a OAS 3.2 pathItem node") and
+      // never emits them into the generated model. An inline AMF fragment is the
+      // ONLY way to exercise the COPY/MOVE label color until AMF adds support;
+      // do NOT attempt to generate these verbs. This inline expanded model (no
+      // `@context`) keeps the test independent of the model generator.
+      const DOC = 'http://a.ml/vocabularies/document#Document';
+      const ENCODES = 'http://a.ml/vocabularies/document#encodes';
+      const WEBAPI = 'http://a.ml/vocabularies/apiContract#WebAPI';
+      const ENDPOINT = 'http://a.ml/vocabularies/apiContract#endpoint';
+      const ENDPOINT_T = 'http://a.ml/vocabularies/apiContract#EndPoint';
+      const OPERATION_T = 'http://a.ml/vocabularies/apiContract#Operation';
+      const SUPPORTED_OP = 'http://a.ml/vocabularies/apiContract#supportedOperation';
+      const PATH = 'http://a.ml/vocabularies/apiContract#path';
+      const METHOD = 'http://a.ml/vocabularies/apiContract#method';
+
+      function buildCopyMoveModel() {
+        return {
+          '@type': [DOC],
+          [ENCODES]: [{
+            '@id': 'amf://id#1',
+            '@type': [WEBAPI],
+            [ENDPOINT]: [{
+              '@id': 'amf://id#10',
+              '@type': [ENDPOINT_T],
+              [PATH]: [{ '@value': '/pets' }],
+              [SUPPORTED_OP]: [{
+                '@id': 'amf://id#13',
+                '@type': [OPERATION_T],
+                [METHOD]: [{ '@value': 'COPY' }],
+              }, {
+                '@id': 'amf://id#14',
+                '@type': [OPERATION_T],
+                [METHOD]: [{ '@value': 'MOVE' }],
+              }],
             }],
           }],
-        }],
-      };
-    }
+        };
+      }
 
-    let element;
+      let element;
 
-    beforeEach(async () => {
-      element = await basicFixture();
-      element.amf = buildQueryModel();
-      // `__amfChanged` defers processing through a setTimeout debouncer.
-      await aTimeout(0);
-      await nextFrame();
-    });
+      beforeEach(async () => {
+        element = await basicFixture();
+        element.amf = buildCopyMoveModel();
+        // `__amfChanged` defers processing through a setTimeout debouncer.
+        await aTimeout(0);
+        await nextFrame();
+      });
 
-    it('renders a QUERY method-label with data-method="QUERY"', () => {
-      const methods = Array.from(
-        element.shadowRoot.querySelectorAll('.method-label')
-      ).map((node) => node.getAttribute('data-method'));
-      assert.include(methods, 'QUERY', 'a method-label carries the raw QUERY value');
-    });
-
-    it('keeps the raw AMF casing (does not lower-case QUERY)', () => {
-      const methods = Array.from(
-        element.shadowRoot.querySelectorAll('.method-label')
-      ).map((node) => node.getAttribute('data-method'));
-      assert.notInclude(methods, 'query', 'QUERY is not silently lower-cased');
-    });
-
-    it('renders COPY and MOVE method-labels with their raw data-method', () => {
-      const methods = Array.from(
-        element.shadowRoot.querySelectorAll('.method-label')
-      ).map((node) => node.getAttribute('data-method'));
-      assert.include(methods, 'COPY', 'a method-label carries the raw COPY value');
-      assert.include(methods, 'MOVE', 'a method-label carries the raw MOVE value');
+      it('renders COPY and MOVE method-labels with their raw data-method', () => {
+        const methods = Array.from(
+          element.shadowRoot.querySelectorAll('.method-label')
+        ).map((node) => node.getAttribute('data-method'));
+        assert.include(methods, 'COPY', 'a method-label carries the raw COPY value');
+        assert.include(methods, 'MOVE', 'a method-label carries the raw MOVE value');
+      });
     });
   });
 });


### PR DESCRIPTION
## @W-23748890

### What

Adds a color badge for the OAS 3.2 `QUERY` HTTP method.

`@api-components/http-method-label` maps the classic verbs (get/post/put/delete/patch/…) plus publish/subscribe, but has no entry for `query` — so QUERY endpoints fall through to the gray `--method-label-default-color`. This adds a local CSS override (teal `#0F9D9D`) keyed on both `data-method='query'` and `data-method='QUERY'`, mirroring the existing publish/subscribe local-override precedent.

Both casings are covered on purpose: AMF emits `apiContract#method="QUERY"` (uppercase) verbatim, which api-navigation and api-summary render raw, while api-method-documentation lowercases it via `ApiUrl.js`.

### Why

TD-0333486 — OAS 3.1/3.2 support in API Console v6. AC2: new OAS 3.2 methods must be legible/distinguishable in the console.

### Color

Teal / cyan `#0F9D9D` (bg `rgba(15,157,157,0.12)`). Read-safe and does not collide with PATCH (purple), GET (green) or POST (blue).

### Tests

Green in chromium + firefox. Inline AMF expanded-model fixtures (generator-independent): renders `data-method`, not lowercased/uppercased incorrectly, `_isGrpc` false.


### Manual testing

<img width="685" height="385" alt="Screenshot 2026-08-20 at 10 19 09 PM" src="https://github.com/user-attachments/assets/54c7d724-f000-43b0-b940-0739cc08ae0c" />


